### PR TITLE
fix: saving an account setting will no longer delete a time zone pref…

### DIFF
--- a/src/account-settings/service.js
+++ b/src/account-settings/service.js
@@ -41,6 +41,9 @@ function unpackFieldErrors(fieldErrors) {
 function unpackAccountResponseData(data) {
   const unpackedData = data;
 
+  // This is handled by preferences
+  if (unpackedData.time_zone !== undefined) delete unpackedData.time_zone;
+
   SOCIAL_PLATFORMS.forEach(({ id, key }) => {
     const platformData = data.social_links.find(({ platform }) => platform === id);
     unpackedData[key] = typeof platformData === 'object' ? platformData.social_link : '';

--- a/src/account-settings/service.js
+++ b/src/account-settings/service.js
@@ -42,7 +42,7 @@ function unpackAccountResponseData(data) {
   const unpackedData = data;
 
   // This is handled by preferences
-  if (unpackedData.time_zone !== undefined) delete unpackedData.time_zone;
+  delete unpackedData.time_zone;
 
   SOCIAL_PLATFORMS.forEach(({ id, key }) => {
     const platformData = data.social_links.find(({ platform }) => platform === id);


### PR DESCRIPTION
The account endpoint returns a null, uneditable time_zone value which collides with our preferences value when saving an account setting. This deletes time_zone when unpacking/transforming account response data.