### PR TITLE
feat: delete my account

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -18,6 +18,7 @@ import { accountSettingsPageSelector } from './selectors';
 import { PageLoading } from '../common';
 import JumpNav from './components/JumpNav';
 import Alert from './components/Alert';
+import DeleteMyAccount from './components/DeleteMyAccount';
 import EditableField from './components/EditableField';
 import PasswordReset from './components/PasswordReset';
 import ThirdPartyAuth from './components/ThirdPartyAuth';
@@ -68,11 +69,11 @@ class AccountSettingsPage extends React.Component {
 
   handleEditableFieldChange = (name, value) => {
     this.props.updateDraft(name, value);
-  }
+  };
 
   handleSubmit = (formId, values) => {
     this.props.saveSettings(formId, values);
-  }
+  };
 
   renderDuplicateTpaProviderMessage() {
     if (!this.props.duplicateTpaProvider) {
@@ -151,6 +152,8 @@ class AccountSettingsPage extends React.Component {
       this.props.timeZoneOptions,
       this.props.countryTimeZoneOptions,
     );
+
+    const hasLinkedSocial = this.props.providers && this.props.providers.length > 0;
 
     return (
       <React.Fragment>
@@ -304,6 +307,14 @@ class AccountSettingsPage extends React.Component {
           <p>{this.props.intl.formatMessage(messages['account.settings.section.linked.accounts.description'])}</p>
           <ThirdPartyAuth />
         </section>
+
+        <section id="delete-account">
+          <DeleteMyAccount
+            isVerifiedAccount={this.props.is_active}
+            hasLinkedSocial={hasLinkedSocial}
+          />
+        </section>
+
       </React.Fragment>
     );
   }
@@ -394,8 +405,10 @@ AccountSettingsPage.propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   })),
   profileDataManager: PropTypes.string,
+  providers: PropTypes.arrayOf(PropTypes.object),
   staticFields: PropTypes.arrayOf(PropTypes.string),
   hiddenFields: PropTypes.arrayOf(PropTypes.string),
+  is_active: PropTypes.bool,
 
   timeZoneOptions: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -423,9 +436,11 @@ AccountSettingsPage.defaultProps = {
   countryTimeZoneOptions: [],
   languageProficiencyOptions: [],
   profileDataManager: null,
+  providers: [],
   staticFields: [],
   hiddenFields: ['secondary_email'],
   duplicateTpaProvider: null,
+  is_active: true,
 };
 
 

--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -8,7 +8,7 @@ const messages = defineMessages({
   },
   'account.settings.loading.message': {
     id: 'account.settings.loading.message',
-    defaultMessage: 'Loading',
+    defaultMessage: 'Loading...',
     description: 'Message when data is being loaded',
   },
   'account.settings.loading.error': {
@@ -267,6 +267,113 @@ const messages = defineMessages({
     id: 'account.settings.field.social.platform.name.facebook',
     defaultMessage: 'Facebook',
     description: 'Label for Facebook',
+  },
+
+  'account.settings.delete.account.header': {
+    id: 'account.settings.delete.account.header',
+    defaultMessage: 'Delete My Account',
+    description: 'Header for the user account deletion area',
+  },
+  'account.settings.delete.account.subheader': {
+    id: 'account.settings.delete.account.subheader',
+    defaultMessage: 'We\'re sorry to see you go!',
+    description: 'A message in the user account deletion area',
+  },
+  'account.settings.delete.account.text.1': {
+    id: 'account.settings.delete.account.text.1',
+    defaultMessage: 'Please note: Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.',
+    description: 'A message in the user account deletion area',
+  },
+  'account.settings.delete.account.text.2': {
+    id: 'account.settings.delete.account.text.2',
+    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    description: 'A message in the user account deletion area',
+  },
+  'account.settings.delete.account.text.3.link': {
+    id: 'account.settings.delete.account.text.3.link',
+    defaultMessage: 'follow the instructions for printing or downloading a certificate',
+    description: 'This text will be a link to a technical support page; it will go in the phrase If you want to make a copy of these for your records, ______ .',
+  },
+  'account.settings.delete.account.text.warning': {
+    id: 'account.settings.delete.account.text.warning',
+    defaultMessage: 'Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on edX.',
+    description: 'A message in the user account deletion area',
+  },
+  'account.settings.delete.account.text.change.instead': {
+    id: 'account.settings.delete.account.text.change.instead',
+    defaultMessage: 'Want to change your email, name, or password instead?',
+    description: 'A message in the user account deletion area',
+  },
+  'account.settings.delete.account.button': {
+    id: 'account.settings.delete.account.button',
+    defaultMessage: 'Delete My Account',
+    description: 'Button label to permanently delete your edX account',
+  },
+  'account.settings.delete.account.please.activate': {
+    id: 'account.settings.delete.account.please.activate',
+    defaultMessage: 'activate your account',
+    description: 'This is the text on a link that goes to the support page.  It is part of this sentence: Before proceeding, please activate your account.',
+  },
+  'account.settings.delete.account.please.unlink': {
+    id: 'account.settings.delete.account.please.unlink',
+    defaultMessage: 'unlink all social media accounts',
+    description: 'This is the text on a link that goes to the support page.  It is part of this sentence: Before proceeding, please unlink all social media accounts.',
+  },
+  'account.settings.delete.account.modal.header': {
+    id: 'account.settings.delete.account.modal.header',
+    defaultMessage: 'Are you sure?',
+    description: 'Title of the dialog asking user to confirm that they want to delete their entire account',
+  },
+  'account.settings.delete.account.modal.text.1': {
+    id: 'account.settings.delete.account.modal.text.1',
+    defaultMessage: 'You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.',
+    description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
+  },
+  'account.settings.delete.account.modal.text.2': {
+    id: 'account.settings.delete.account.modal.text.2',
+    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
+  },
+  'account.settings.delete.account.modal.enter.password': {
+    id: 'account.settings.delete.account.modal.enter.password',
+    defaultMessage: 'If you still wish to continue and delete your account, please enter your account password:',
+    description: 'Asking for the user\'s account password',
+  },
+  'account.settings.delete.account.modal.password': {
+    id: 'account.settings.delete.account.modal.password',
+    defaultMessage: 'Password',
+    description: 'Label for the input box asking for the user\'s account password',
+  },
+  'account.settings.delete.account.modal.confirm.delete': {
+    id: 'account.settings.delete.account.modal.confirm.delete',
+    defaultMessage: 'Yes, Delete',
+    description: 'Button label for user to confirm it is okay to delete their account',
+  },
+  'account.settings.delete.error.unable.to.delete': {
+    id: 'account.settings.delete.error.unable.to.delete',
+    defaultMessage: 'Unable to delete account',
+    description: 'Error message when account deletion failed',
+  },
+  'account.settings.delete.error.unable.to.delete.details': {
+    id: 'account.settings.delete.error.unable.to.delete.details',
+    defaultMessage: 'Sorry, there was an error trying to process your request. Please try again later.',
+    description: 'Error message when account deletion failed',
+  },
+
+  'account.settings.delete.account.modal.after.header': {
+    id: 'account.settings.delete.account.modal.after.header',
+    defaultMessage: 'We\'re sorry to see you go!  Your account will be deleted shortly.',
+    description: 'Title displayed after user account is deleted',
+  },
+  'account.settings.delete.account.modal.after.text': {
+    id: 'account.settings.delete.account.modal.after.text',
+    defaultMessage: 'Account deletion, including removal from email lists, may take a few weeks to fully process through our system. If you want to opt-out of emails before then, please unsubscribe from the footer of any email.',
+    description: 'Text displayed after user account is deleted',
+  },
+  'account.settings.delete.account.modal.after.button': {
+    id: 'account.settings.delete.account.modal.after.button',
+    defaultMessage: 'Close',
+    description: 'Label on button to close a dialog',
   },
 
   'account.settings.editable.field.password.reset.button': {

--- a/src/account-settings/actions.js
+++ b/src/account-settings/actions.js
@@ -5,6 +5,8 @@ const { AsyncActionType } = utils;
 export const FETCH_SETTINGS = new AsyncActionType('ACCOUNT_SETTINGS', 'FETCH_SETTINGS');
 export const SAVE_SETTINGS = new AsyncActionType('ACCOUNT_SETTINGS', 'SAVE_SETTINGS');
 export const FETCH_TIME_ZONES = new AsyncActionType('ACCOUNT_SETTINGS', 'FETCH_TIME_ZONES');
+export const DELETE_ACCOUNT = new AsyncActionType('ACCOUNT_SETTINGS', 'DELETE_ACCOUNT');
+DELETE_ACCOUNT.CONFIRMATION = 'ACCOUNT_SETTINGS__DELETE_ACCOUNT__CONFIRMATION';
 export const RESET_PASSWORD = new AsyncActionType('ACCOUNT_SETTINGS', 'RESET_PASSWORD');
 export const SAVE_PREVIOUS_SITE_LANGUAGE = 'SAVE_PREVIOUS_SITE_LANGUAGE';
 export const OPEN_FORM = 'OPEN_FORM';
@@ -102,6 +104,33 @@ export const saveSettingsFailure = ({ fieldErrors, message }) => ({
 export const savePreviousSiteLanguage = previousSiteLanguage => ({
   type: SAVE_PREVIOUS_SITE_LANGUAGE,
   payload: { previousSiteLanguage },
+});
+
+// DELETE ACCOUNT ACTIONS
+
+export const deleteAccount = password => ({
+  type: DELETE_ACCOUNT.BASE,
+  payload: { password },
+});
+
+export const deleteAccountConfirmation = () => ({
+  type: DELETE_ACCOUNT.CONFIRMATION,
+});
+
+export const deleteAccountBegin = () => ({
+  type: DELETE_ACCOUNT.BEGIN,
+});
+
+export const deleteAccountSuccess = () => ({
+  type: DELETE_ACCOUNT.SUCCESS,
+});
+
+export const deleteAccountFailure = () => ({
+  type: DELETE_ACCOUNT.FAILURE,
+});
+
+export const deleteAccountReset = () => ({
+  type: DELETE_ACCOUNT.RESET,
 });
 
 // RESET PASSWORD ACTIONS

--- a/src/account-settings/components/DeleteMyAccount.jsx
+++ b/src/account-settings/components/DeleteMyAccount.jsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
+import { Button, Hyperlink, Input, Modal, ValidationFormGroup } from '@edx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExclamationCircle, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { FormattedMessage } from 'react-intl';
+import { configuration } from '../../environment';
+import Alert from './Alert';
+import { deleteAccount, deleteAccountConfirmation, deleteAccountReset } from '../actions';
+import messages from '../AccountSettingsPage.messages';
+
+const passwordFieldId = 'passwordFieldId';
+
+class DeleteMyAccount extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      password: '',
+    };
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
+    this.handlePasswordChange = this.handlePasswordChange.bind(this);
+    this.handleFinalClose = this.handleFinalClose.bind(this);
+  }
+
+  handleSubmit() {
+    this.props.deleteAccount(this.state.password);
+  }
+
+  handleCancel() {
+    this.setState({ password: '' });
+    this.props.deleteAccountReset();
+  }
+
+  handlePasswordChange(e) {
+    this.setState({ password: e.target.value });
+  }
+
+  handleFinalClose() {
+    global.location = configuration.LOGOUT_URL;
+  }
+
+  renderPrintingInstructions() {
+    return (<FormattedMessage
+      id="account.settings.delete.account.text.3"
+      defaultMessage="You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, {actionLink}."
+      description="A message in the user account deletion area"
+      values={{
+        actionLink: (
+          <Hyperlink
+            destination="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
+          >
+            {this.props.intl.formatMessage(messages['account.settings.delete.account.text.3.link'])}
+          </Hyperlink>
+          ),
+      }}
+    />);
+  }
+
+  renderBeforeProceedingBanner(instructionMessageId, supportUrl) {
+    return (
+      <Alert
+        className="alert-warning mt-n2"
+        icon={<FontAwesomeIcon className="mr-2" icon={faExclamationTriangle} />}
+      >
+        <FormattedMessage
+          id="account.settings.delete.account.before.proceeding"
+          defaultMessage="Before proceeding, please {actionLink}."
+          description="Error that appears if you are trying to delete your edX account, but something about your account needs attention first.  The actionLink will be instructions, such as 'unlink your Facebook account'."
+          values={{
+            actionLink: (
+              <Hyperlink
+                destination={supportUrl}
+              >
+                {this.props.intl.formatMessage(messages[instructionMessageId])}
+              </Hyperlink>
+            ),
+          }}
+        />
+      </Alert>);
+  }
+
+  render() {
+    const { hasLinkedSocial, isVerifiedAccount, intl } = this.props;
+    const canDelete = isVerifiedAccount && !hasLinkedSocial;
+
+    return (
+      <div>
+        <h2 className="section-heading">
+          {intl.formatMessage(messages['account.settings.delete.account.header'])}
+        </h2>
+        <p>
+          {intl.formatMessage(messages['account.settings.delete.account.subheader'])}
+        </p>
+        <p>
+          {intl.formatMessage(messages['account.settings.delete.account.text.1'])}
+        </p>
+        <p>
+          {intl.formatMessage(messages['account.settings.delete.account.text.2'])}
+        </p>
+        <p>
+          {this.renderPrintingInstructions()}
+        </p>
+        <p className="text-danger h6">
+          {intl.formatMessage(messages['account.settings.delete.account.text.warning'])}
+        </p>
+        <p>
+          <Hyperlink destination="https://support.edx.org/hc/en-us/sections/115004139268-Manage-Your-Account-Settings">
+            {intl.formatMessage(messages['account.settings.delete.account.text.change.instead'])}
+          </Hyperlink>
+        </p>
+        <p>
+          <Button
+            className="btn-outline-danger"
+            onClick={canDelete ? this.props.deleteAccountConfirmation : null}
+            disabled={!canDelete}
+          >
+            {intl.formatMessage(messages['account.settings.delete.account.button'])}
+          </Button>
+        </p>
+
+        {isVerifiedAccount ? null
+          :
+          this.renderBeforeProceedingBanner('account.settings.delete.account.please.activate', 'https://support.edx.org/hc/en-us/articles/115000940568-How-do-I-activate-my-account-')
+        }
+
+        {hasLinkedSocial ?
+          this.renderBeforeProceedingBanner('account.settings.delete.account.please.unlink', 'https://support.edx.org/hc/en-us/articles/207206067')
+          : null
+        }
+
+        <Modal
+          open={this.props.deletionStatus === 'confirming'}
+          title={intl.formatMessage(messages['account.settings.delete.account.modal.header'])}
+          body={(
+            <div>
+
+              {this.props.deletionError ?
+                <Alert
+                  className="alert-danger mt-n2"
+                  icon={<FontAwesomeIcon className="mr-2" icon={faExclamationCircle} />}
+                >
+                  <p className="h6">
+                    {intl.formatMessage(messages['account.settings.delete.error.unable.to.delete'])}
+                  </p>
+                  <p className="text-danger">
+                    {intl.formatMessage(messages['account.settings.delete.error.unable.to.delete.details'])}
+                  </p>
+                </Alert>
+                : null
+              }
+
+              <Alert
+                className="alert-warning mt-n2"
+                icon={<FontAwesomeIcon className="mr-2" icon={faExclamationTriangle} />}
+              >
+                <p className="h6">
+                  {intl.formatMessage(messages['account.settings.delete.account.modal.text.1'])}
+                </p>
+                <p>
+                  {intl.formatMessage(messages['account.settings.delete.account.modal.text.2'])}
+                </p>
+                <p>
+                  {this.renderPrintingInstructions()}
+                </p>
+              </Alert>
+              <p className="h6">
+                {intl.formatMessage(messages['account.settings.delete.account.modal.enter.password'])}
+              </p>
+              <ValidationFormGroup
+                for={passwordFieldId}
+                invalid={this.props.deletionError != null}
+                invalidMessage={intl.formatMessage(messages['account.settings.delete.error.unable.to.delete'])}
+              >
+                <label
+                  className="d-block"
+                  htmlFor={passwordFieldId}
+                >{intl.formatMessage(messages['account.settings.delete.account.modal.password'])}
+                </label>
+                <Input
+                  name="password"
+                  id={passwordFieldId}
+                  type="password"
+                  value={this.state.password}
+                  onChange={this.handlePasswordChange}
+                />
+              </ValidationFormGroup>
+            </div>
+          )}
+          buttons={[
+            <Button className="btn-danger" onClick={this.handleSubmit} disabled={this.state.password.length === 0}>
+              {intl.formatMessage(messages['account.settings.delete.account.modal.confirm.delete'])}
+            </Button>]}
+          closeText={intl.formatMessage(messages['account.settings.editable.field.action.cancel'])}
+          renderHeaderCloseButton={false}
+          onClose={this.handleCancel}
+        />
+
+        <Modal
+          open={this.props.deletionStatus === 'deleted'}
+          title={intl.formatMessage(messages['account.settings.delete.account.modal.after.header'])}
+          body={(
+            <div>
+              <p className="h6">
+                {intl.formatMessage(messages['account.settings.delete.account.modal.after.text'])}
+              </p>
+            </div>
+          )}
+          closeText={intl.formatMessage(messages['account.settings.delete.account.modal.after.button'])}
+          renderHeaderCloseButton={false}
+          onClose={this.handleFinalClose}
+        />
+      </div>
+    );
+  }
+}
+
+DeleteMyAccount.propTypes = {
+  deleteAccount: PropTypes.func.isRequired,
+  deleteAccountReset: PropTypes.func.isRequired,
+  deleteAccountConfirmation: PropTypes.func.isRequired,
+  deletionStatus: PropTypes.oneOf(['confirming', 'pending', 'deleted', 'failed']),
+  deletionError: PropTypes.oneOf(['empty-password', 'server']),
+  hasLinkedSocial: PropTypes.bool,
+  isVerifiedAccount: PropTypes.bool,
+  intl: intlShape.isRequired,
+};
+
+DeleteMyAccount.defaultProps = {
+  hasLinkedSocial: false,
+  isVerifiedAccount: true,
+  deletionStatus: null,
+  deletionError: null,
+};
+
+export default connect(
+  state => ({
+    deletionError: state.accountSettings.deletionError,
+    deletionStatus: state.accountSettings.deletionStatus,
+  }),
+  {
+    deleteAccount,
+    deleteAccountConfirmation,
+    deleteAccountReset,
+  },
+)(injectIntl(DeleteMyAccount));

--- a/src/account-settings/components/JumpNav.jsx
+++ b/src/account-settings/components/JumpNav.jsx
@@ -34,6 +34,11 @@ function JumpNav({ intl }) {
             {intl.formatMessage(messages['account.settings.section.linked.accounts'])}
           </NavHashLink>
         </li>
+        <li>
+          <NavHashLink to="#delete-account">
+            {intl.formatMessage(messages['account.settings.delete.account.header'])}
+          </NavHashLink>
+        </li>
       </ul>
     </div>
   );

--- a/src/account-settings/reducers.js
+++ b/src/account-settings/reducers.js
@@ -9,6 +9,7 @@ import {
   DISCONNECT_AUTH,
   UPDATE_DRAFT,
   RESET_DRAFTS,
+  DELETE_ACCOUNT,
 } from './actions';
 
 export const defaultState = {
@@ -21,6 +22,7 @@ export const defaultState = {
   confirmationValues: {},
   drafts: {},
   saveState: null,
+  deletionStatus: null,
   resetPasswordState: null,
   timeZones: [],
   countryTimeZones: [],
@@ -137,6 +139,39 @@ const accountSettingsReducer = (state = defaultState, action) => {
         ...state,
         previousSiteLanguage: action.payload.previousSiteLanguage,
       };
+
+    case DELETE_ACCOUNT.CONFIRMATION:
+      return {
+        ...state,
+        deletionStatus: 'confirming',
+      };
+
+    case DELETE_ACCOUNT.BEGIN:
+      return {
+        ...state,
+        deletionStatus: 'pending',
+      };
+
+    case DELETE_ACCOUNT.SUCCESS:
+      return {
+        ...state,
+        deletionStatus: 'deleted',
+      };
+
+    case DELETE_ACCOUNT.FAILURE:
+      return {
+        ...state,
+        deletionStatus: 'failed',
+        deletionError: 'server',
+      };
+
+    case DELETE_ACCOUNT.RESET:
+      return {
+        ...state,
+        deletionStatus: null,
+        deletionError: null,
+      };
+
     case RESET_PASSWORD.BEGIN:
       return {
         ...state,

--- a/src/account-settings/sagas.js
+++ b/src/account-settings/sagas.js
@@ -1,7 +1,7 @@
 
 import { call, put, delay, takeEvery, select, all } from 'redux-saga/effects';
 import { push } from 'connected-react-router';
-import { LoggingService, logAPIErrorResponse } from '@edx/frontend-logging';
+import { logAPIErrorResponse } from '@edx/frontend-logging';
 
 // Actions
 import {
@@ -111,7 +111,7 @@ export function* handleDeleteAccount(action) {
     if (typeof e.response.data === 'string') {
       yield put(deleteAccountFailure());
     } else {
-      LoggingService.logAPIErrorResponse(e);
+      logAPIErrorResponse(e);
       yield put(push('/error'));
     }
   }

--- a/src/account-settings/sagas.js
+++ b/src/account-settings/sagas.js
@@ -1,7 +1,7 @@
 
 import { call, put, delay, takeEvery, select, all } from 'redux-saga/effects';
 import { push } from 'connected-react-router';
-import { logAPIErrorResponse } from '@edx/frontend-logging';
+import { LoggingService, logAPIErrorResponse } from '@edx/frontend-logging';
 
 // Actions
 import {
@@ -26,6 +26,10 @@ import {
   disconnectAuthSuccess,
   disconnectAuthFailure,
   disconnectAuthReset,
+  DELETE_ACCOUNT,
+  deleteAccountBegin,
+  deleteAccountSuccess,
+  deleteAccountFailure,
 } from './actions';
 import { usernameSelector, userRolesSelector, siteLanguageSelector } from './selectors';
 
@@ -98,6 +102,21 @@ export function* handleSaveSettings(action) {
   }
 }
 
+export function* handleDeleteAccount(action) {
+  try {
+    yield put(deleteAccountBegin());
+    const response = yield call(ApiService.postDeleteAccount, action.payload.password);
+    yield put(deleteAccountSuccess(response));
+  } catch (e) {
+    if (typeof e.response.data === 'string') {
+      yield put(deleteAccountFailure());
+    } else {
+      LoggingService.logAPIErrorResponse(e);
+      yield put(push('/error'));
+    }
+  }
+}
+
 export function* handleResetPassword(action) {
   try {
     yield put(resetPasswordBegin());
@@ -136,6 +155,7 @@ export function* handleDisconnectAuth(action) {
 export default function* saga() {
   yield takeEvery(FETCH_SETTINGS.BASE, handleFetchSettings);
   yield takeEvery(SAVE_SETTINGS.BASE, handleSaveSettings);
+  yield takeEvery(DELETE_ACCOUNT.BASE, handleDeleteAccount);
   yield takeEvery(RESET_PASSWORD.BASE, handleResetPassword);
   yield takeEvery(FETCH_TIME_ZONES.BASE, handleFetchTimeZones);
   yield takeEvery(DISCONNECT_AUTH.BASE, handleDisconnectAuth);

--- a/src/account-settings/service.js
+++ b/src/account-settings/service.js
@@ -8,6 +8,7 @@ let config = {
   PREFERENCES_API_BASE_URL: null,
   ECOMMERCE_API_BASE_URL: null,
   LMS_BASE_URL: null,
+  DELETE_ACCOUNT_URL: null,
   PASSWORD_RESET_URL: null,
 };
 
@@ -59,6 +60,7 @@ function unpackAccountResponseData(data) {
 
   return unpackedData;
 }
+
 function packAccountCommitData(commitData) {
   const packedData = commitData;
 
@@ -75,7 +77,6 @@ function packAccountCommitData(commitData) {
   }
   return packedData;
 }
-
 
 function handleRequestError(error) {
   if (error.response && error.response.data.field_errors) {
@@ -119,6 +120,13 @@ export async function patchPreferences(username, commitValues) {
     .catch(handleRequestError);
 
   return commitValues;
+}
+
+export async function postDeleteAccount(password) {
+  const { data } = await apiClient
+    .post(config.DELETE_ACCOUNT_URL, { password })
+    .catch(handleRequestError);
+  return data;
 }
 
 export async function getThirdPartyAuthProviders() {

--- a/src/components/App.messages.jsx
+++ b/src/components/App.messages.jsx
@@ -53,7 +53,7 @@ const messages = defineMessages({
   },
   'app.loading.message': {
     id: 'app.loading.message',
-    defaultMessage: 'Loading',
+    defaultMessage: 'Loading...',
     description: 'Message shown when page content is loading.',
   },
 });

--- a/src/environment.js
+++ b/src/environment.js
@@ -36,6 +36,7 @@ export const configuration = {
   CERTIFICATES_API_BASE_URL: `${process.env.LMS_BASE_URL}/api/certificates/v0/certificates`,
   VIEW_MY_RECORDS_URL: `${process.env.CREDENTIALS_BASE_URL}/records`,
   ECOMMERCE_API_BASE_URL: `${process.env.ECOMMERCE_BASE_URL}/api/v2`,
+  DELETE_ACCOUNT_URL: `${process.env.LMS_BASE_URL}/api/user/v1/accounts/deactivate_logout/`,
   PASSWORD_RESET_URL: `${process.env.LMS_BASE_URL}/password_reset/`,
 };
 


### PR DESCRIPTION
Still needs:

- Add "you must enter a password" error state on confirmation modal if the password field loses focus while it's blank-- I propose doing this as a fast follow.

Note: Seeing console error: "Each child in a list should have a unique "key" prop."  (@abutterworth this looks like a Paragon thing with Modal's Buttons)