### PR TITLE
fix: add xhr header to eliminate redirects on setlang

### DIFF
--- a/src/site-language/service.js
+++ b/src/site-language/service.js
@@ -37,10 +37,9 @@ async function patchPreferences(username, params) {
 async function postSetLang(code) {
   const formData = new FormData();
   formData.append('language', getAssumedServerLanguageCode(code));
-  formData.append('next', `${config.BASE_URL}/account-settings`);
 
   await apiClient.post(`${config.LMS_BASE_URL}/i18n/setlang/`, formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
   });
 }
 


### PR DESCRIPTION
Adding the `X-Requested-With: XMLHttpRequest` header to the post request shows Django that this is an AJAX request so it will no longer redirect our request (it was getting bounced to edx.org and redirected again to edx.org/dashboard taking seconds to load).

Related Axios Thread: https://github.com/axios/axios/issues/1322
Django Reference: https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#the-set-language-redirect-view

