### PR TITLE
fix(delete my account): correctly expose Third Party Auth providers

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -153,7 +153,7 @@ class AccountSettingsPage extends React.Component {
       this.props.countryTimeZoneOptions,
     );
 
-    const hasLinkedSocial = this.props.providers && this.props.providers.length > 0;
+    const hasLinkedTPA = this.props.tpaProviders && this.props.tpaProviders.length > 0;
 
     return (
       <React.Fragment>
@@ -311,7 +311,7 @@ class AccountSettingsPage extends React.Component {
         <section id="delete-account">
           <DeleteMyAccount
             isVerifiedAccount={this.props.isActive}
-            hasLinkedSocial={hasLinkedSocial}
+            hasLinkedTPA={hasLinkedTPA}
           />
         </section>
 
@@ -405,7 +405,6 @@ AccountSettingsPage.propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   })),
   profileDataManager: PropTypes.string,
-  providers: PropTypes.arrayOf(PropTypes.object),
   staticFields: PropTypes.arrayOf(PropTypes.string),
   hiddenFields: PropTypes.arrayOf(PropTypes.string),
   isActive: PropTypes.bool,
@@ -423,6 +422,7 @@ AccountSettingsPage.propTypes = {
   saveSettings: PropTypes.func.isRequired,
   fetchSettings: PropTypes.func.isRequired,
   duplicateTpaProvider: PropTypes.string,
+  tpaProviders: PropTypes.arrayOf(PropTypes.object),
 };
 
 AccountSettingsPage.defaultProps = {
@@ -436,10 +436,10 @@ AccountSettingsPage.defaultProps = {
   countryTimeZoneOptions: [],
   languageProficiencyOptions: [],
   profileDataManager: null,
-  providers: [],
   staticFields: [],
   hiddenFields: ['secondary_email'],
   duplicateTpaProvider: null,
+  tpaProviders: [],
   isActive: true,
 };
 

--- a/src/account-settings/components/DeleteMyAccount.jsx
+++ b/src/account-settings/components/DeleteMyAccount.jsx
@@ -83,8 +83,8 @@ class DeleteMyAccount extends React.Component {
   }
 
   render() {
-    const { hasLinkedSocial, isVerifiedAccount, intl } = this.props;
-    const canDelete = isVerifiedAccount && !hasLinkedSocial;
+    const { hasLinkedTPA, isVerifiedAccount, intl } = this.props;
+    const canDelete = isVerifiedAccount && !hasLinkedTPA;
 
     return (
       <div>
@@ -126,7 +126,7 @@ class DeleteMyAccount extends React.Component {
           this.renderBeforeProceedingBanner('account.settings.delete.account.please.activate', 'https://support.edx.org/hc/en-us/articles/115000940568-How-do-I-activate-my-account-')
         }
 
-        {hasLinkedSocial ?
+        {hasLinkedTPA ?
           this.renderBeforeProceedingBanner('account.settings.delete.account.please.unlink', 'https://support.edx.org/hc/en-us/articles/207206067')
           : null
         }
@@ -223,13 +223,13 @@ DeleteMyAccount.propTypes = {
   deleteAccountReset: PropTypes.func.isRequired,
   accountDeletionState: PropTypes.oneOf(['confirming', 'pending', 'deleted', 'failed']),
   deletionError: PropTypes.oneOf(['empty-password', 'server']),
-  hasLinkedSocial: PropTypes.bool,
+  hasLinkedTPA: PropTypes.bool,
   isVerifiedAccount: PropTypes.bool,
   intl: intlShape.isRequired,
 };
 
 DeleteMyAccount.defaultProps = {
-  hasLinkedSocial: false,
+  hasLinkedTPA: false,
   isVerifiedAccount: true,
   accountDeletionState: null,
   deletionError: null,

--- a/src/account-settings/selectors.js
+++ b/src/account-settings/selectors.js
@@ -217,5 +217,6 @@ export const accountSettingsPageSelector = createSelector(
     staticFields,
     hiddenFields,
     duplicateTpaProvider,
+    tpaProviders: accountSettings.authProviders,
   }),
 );


### PR DESCRIPTION
Also change the misleading variable name hasLinkedSocial.  The knowledge base refers to TPAs as "linking to a social media account" (sigh) but they're referred to as TPA providers in the rest of this repo.