### PR TITLE
Fix third party auth naming issues

### DIFF
--- a/src/account-settings/reducers.js
+++ b/src/account-settings/reducers.js
@@ -48,7 +48,10 @@ const reducer = (state = defaultState, action) => {
       return {
         ...state,
         values: Object.assign({}, state.values, action.payload.values),
-        authProviders: action.payload.thirdPartyAuthProviders,
+        // Dump the providers into thirdPartyAuth.
+        thirdPartyAuth: Object.assign({}, state.thirdPartyAuth, {
+          providers: action.payload.thirdPartyAuthProviders,
+        }),
         profileDataManager: action.payload.profileDataManager,
         timeZones: action.payload.timeZones,
         loading: false,

--- a/src/account-settings/third-party-auth/data/reducers.js
+++ b/src/account-settings/third-party-auth/data/reducers.js
@@ -1,7 +1,7 @@
 import { DISCONNECT_AUTH } from './actions';
 
 export const defaultState = {
-  authProviders: [],
+  providers: [],
   disconnectionStatuses: {},
   errors: {},
 };
@@ -24,7 +24,7 @@ const reducer = (state = defaultState, action = null) => {
             ...state.disconnectionStatuses,
             [action.payload.providerId]: 'complete',
           },
-          authProviders: action.payload.thirdPartyAuthProviders,
+          providers: action.payload.thirdPartyAuthProviders,
         };
       case DISCONNECT_AUTH.FAILURE:
         return {


### PR DESCRIPTION
Two problems:

- The auth providers were being added to the wrong part of the store.
- The ThirdPartyAuth component expected them to have the name “providers”, not “authProviders” - great reason to keep names consistent!