### PR TITLE
Small refactor to make updating the site language sequential

### DIFF
--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -71,10 +71,13 @@ export function* handleSaveSettings(action) {
     let savedValues = null;
     if (formId === 'siteLanguage') {
       const previousSiteLanguage = yield select(siteLanguageSelector);
-      yield all([
-        call(patchPreferences, username, { prefLang: commitValues }),
-        call(postSetLang, commitValues),
-      ]);
+
+      // The following two requests need to be done sequentially, with patching preferences before
+      // the post to setlang.  They used to be done in parallel, but this might create ambiguous
+      // behavior.
+      yield call(patchPreferences, username, { prefLang: commitValues });
+      yield call(postSetLang, commitValues);
+
       yield put(setLocale(commitValues));
       yield put(savePreviousSiteLanguage(previousSiteLanguage.savedValue));
       handleRtl();


### PR DESCRIPTION
We were calling the setlang and preferences endpoints in parallel - it’s not clear whether this might create a race condition.  Instead, we now call preferences first, followed by i18n/setlang.  This matches the behavior of the django-based account settings page.