### PR TITLE
Fix timezone dropdown under Site Preferences

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -388,7 +388,7 @@ class AccountSettingsPage extends React.Component {
           <EditableField
             name="time_zone"
             type="select"
-            value={this.props.formValues.time_zone || ''}
+            value={this.props.formValues.time_zone}
             options={timeZoneOptions}
             label={this.props.intl.formatMessage(messages['account.settings.field.time.zone'])}
             emptyLabel={this.props.intl.formatMessage(messages['account.settings.field.time.zone.empty'])}


### PR DESCRIPTION
This patch would fix timezone dropdown which
doesn't change  value on selection.

PROD-1349