### PR TITLE
ENT-2741: Fixed Profile Manager Banner Scenario

### DIFF
--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -138,11 +138,10 @@ export async function getProfileDataManager(username, userRoles) {
     const { data } = await getAuthenticatedHttpClient().get(url).catch(handleRequestError);
 
     if ('results' in data) {
-      for (let i = 0; i < data.results.length; i += 1) {
-        const enterprise = data.results[i].enterprise_customer;
-        if (enterprise.sync_learner_profile_data) {
-          return enterprise.name;
-        }
+      const enterprise = data.results[0].enterprise_customer;
+      // To ensure that enterprise returned is current enterprise & it manages profile settings
+      if (enterprise.sync_learner_profile_data) {
+        return enterprise.name;
       }
     }
   }


### PR DESCRIPTION
Profile manager banner should only be visible if:

- a learner is linked to an enterprise
- that enterprise manages the settings

Also, it should display the name of the active enterprise in case if a learner is linked to multiple enterprises. 

**Jira**: https://openedx.atlassian.net/browse/ENT-2741