### PR TITLE
MICROBA-hotfix: coaching sign-up save phone number

### DIFF
--- a/src/account-settings/coaching/CoachingConsent.jsx
+++ b/src/account-settings/coaching/CoachingConsent.jsx
@@ -132,14 +132,14 @@ class CoachingConsent extends React.Component {
     const coachingValues = this.props.formValues.coaching;
 
     // These will overwrite each other's redux states (see componentDidUpdate note)
-    this.props.saveSettings('name', fullName);
-    this.props.saveSettings('phone_number', phoneNumber);
-    this.props.saveSettings('coaching', {
+    await this.props.saveSettings('coaching', {
       ...coachingValues,
       phone_number: phoneNumber,
       coaching_consent: true,
       consent_form_seen: true,
     });
+    await this.props.saveSettings('name', fullName);
+    await this.props.saveSettings('phone_number', phoneNumber);
   }
 
   async declineCoaching(e) {

--- a/src/account-settings/coaching/data/service.js
+++ b/src/account-settings/coaching/data/service.js
@@ -1,5 +1,6 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
+import get from 'lodash.get';
 
 /**
  * get all settings related to the coaching plugin. Settings used
@@ -39,9 +40,11 @@ export async function patchCoachingPreferences(userId, commitValues) {
     .catch((error) => {
       const apiError = Object.create(error);
       apiError.fieldErrors = JSON.parse(error.customAttributes.httpErrorResponseData);
-      // eslint-disable-next-line prefer-destructuring
-      apiError.fieldErrors.coaching = apiError.fieldErrors.phone_number[0];
-      delete apiError.fieldErrors.phone_number;
+      if (get(apiError, 'fieldErrors.phone_number')) {
+        // eslint-disable-next-line prefer-destructuring
+        apiError.fieldErrors.coaching = apiError.fieldErrors.phone_number[0];
+        delete apiError.fieldErrors.phone_number;
+      }
       throw apiError;
     });
   return commitValues;


### PR DESCRIPTION
Before this fix, we were having an issues where upon the first time a
user signs up with the coaching form, the phone number would not save.
This was because of the way we patch the user in the form. The phone
number was saving properly, then getting overwritten with `null`.

This fixes that issue, and also cleans up an error message.