### PR TITLE
Reset coaching submission state on submit

### DIFF
--- a/src/account-settings/coaching/CoachingConsent.jsx
+++ b/src/account-settings/coaching/CoachingConsent.jsx
@@ -125,6 +125,7 @@ class CoachingConsent extends React.Component {
     this.setState({
       formErrors: {},
       formSubmitted: true,
+      declineSubmitted: false,
     });
     // Must store target values or they disappear before the async function can use them.
     const fullName = e.target.fullName.value;
@@ -147,6 +148,7 @@ class CoachingConsent extends React.Component {
     this.setState({
       formErrors: {},
       declineSubmitted: true,
+      formSubmitted: false,
     });
     // Must store target values or they disappear before the async function can use them.
     const coachingValues = this.props.formValues.coaching;

--- a/src/account-settings/coaching/data/service.js
+++ b/src/account-settings/coaching/data/service.js
@@ -8,20 +8,8 @@ import get from 'lodash.get';
  * @param {Number} userId users are identified in the api by LMS id
  */
 export async function getCoachingPreferences(userId) {
-  let data = null;
-  try {
-    ({ data } = await getAuthenticatedHttpClient()
-      .get(`${getConfig().LMS_BASE_URL}/api/coaching/v1/users/${userId}/`));
-  } catch (error) {
-    // Default values so the client doesn't fail if the user doesn't have an entry in the
-    // UserCoaching model yet.
-    data = {
-      coaching_consent: false,
-      user: userId,
-      eligible_for_coaching: false,
-      consent_form_seen: false,
-    };
-  }
+  const { data } = await getAuthenticatedHttpClient()
+    .get(`${getConfig().LMS_BASE_URL}/api/coaching/v1/users/${userId}/`);
   return data;
 }
 


### PR DESCRIPTION
Prior to this, if you attempted to sign up for coaching and failed, then went to decline, you would be sent to the success screen instead of redirected. This also removes the default from the coaching API check now that it won't 404 when the user requests their own data. 