### PR TITLE
Prevent phone_number save on coaching save failure

### DIFF
--- a/src/account-settings/data/actions.js
+++ b/src/account-settings/data/actions.js
@@ -2,6 +2,7 @@ import { AsyncActionType } from './utils';
 
 export const FETCH_SETTINGS = new AsyncActionType('ACCOUNT_SETTINGS', 'FETCH_SETTINGS');
 export const SAVE_SETTINGS = new AsyncActionType('ACCOUNT_SETTINGS', 'SAVE_SETTINGS');
+export const SAVE_MULTIPLE_SETTINGS = new AsyncActionType('ACCOUNT_SETTINGS', 'SAVE_MULTIPLE_SETTINGS');
 export const FETCH_TIME_ZONES = new AsyncActionType('ACCOUNT_SETTINGS', 'FETCH_TIME_ZONES');
 export const SAVE_PREVIOUS_SITE_LANGUAGE = 'SAVE_PREVIOUS_SITE_LANGUAGE';
 export const OPEN_FORM = 'OPEN_FORM';
@@ -97,6 +98,25 @@ export const saveSettingsFailure = ({ fieldErrors, message }) => ({
 export const savePreviousSiteLanguage = previousSiteLanguage => ({
   type: SAVE_PREVIOUS_SITE_LANGUAGE,
   payload: { previousSiteLanguage },
+});
+
+export const saveMultipleSettings = settingsArray => ({
+  type: SAVE_MULTIPLE_SETTINGS.BASE,
+  payload: { settingsArray },
+});
+
+export const saveMultipleSettingsBegin = () => ({
+  type: SAVE_MULTIPLE_SETTINGS.BEGIN,
+});
+
+export const saveMultipleSettingsSuccess = settingsArray => ({
+  type: SAVE_MULTIPLE_SETTINGS.SUCCESS,
+  payload: { settingsArray },
+});
+
+export const saveMultipleSettingsFailure = ({ fieldErrors, message }) => ({
+  type: SAVE_MULTIPLE_SETTINGS.FAILURE,
+  payload: { errors: fieldErrors, message },
 });
 
 // FETCH TIME_ZONE ACTIONS

--- a/src/account-settings/data/reducers.js
+++ b/src/account-settings/data/reducers.js
@@ -7,6 +7,7 @@ import {
   SAVE_PREVIOUS_SITE_LANGUAGE,
   UPDATE_DRAFT,
   RESET_DRAFTS,
+  SAVE_MULTIPLE_SETTINGS,
 } from './actions';
 
 import { reducer as deleteAccountReducer, DELETE_ACCOUNT } from '../delete-account';
@@ -143,6 +144,24 @@ const reducer = (state = defaultState, action) => {
       return {
         ...state,
         previousSiteLanguage: action.payload.previousSiteLanguage,
+      };
+    case SAVE_MULTIPLE_SETTINGS.BEGIN:
+      return {
+        ...state,
+        saveState: 'pending',
+      };
+
+    case SAVE_MULTIPLE_SETTINGS.SUCCESS:
+      return {
+        ...state,
+        saveState: 'success',
+      };
+
+    case SAVE_MULTIPLE_SETTINGS.FAILURE:
+      return {
+        ...state,
+        saveState: 'error',
+        errors: Object.assign({}, state.errors, action.payload.errors),
       };
 
     case FETCH_TIME_ZONES.SUCCESS:


### PR DESCRIPTION
Originally, we had it set up so that the coaching consent form saved 33
values in parallel. This add a new saga (saveMultipleSettings) to save
those 3 values in sync. This way, if one fails, the rest of the calls
fail.

Something to watch out for here: the order matters. The array that you
give the save function must be ordered in the way you need the data
saved.