### PR TITLE
MB-366 don't save non eligible coaching number

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,4 +17,4 @@ SITE_NAME='edX'
 SUPPORT_URL='http://localhost:18000/support'
 USER_INFO_COOKIE_NAME='edx-user-info'
 # Temporary, Remove this once we are ready to release the feature.
-COACHING_ENABLED=''
+COACHING_ENABLED=true

--- a/src/account-settings/coaching/CoachingConsent.jsx
+++ b/src/account-settings/coaching/CoachingConsent.jsx
@@ -96,7 +96,7 @@ class CoachingConsent extends React.Component {
     // Check if all values from the form have confirmation values
     if (
       this.state.formSubmitted &&
-      this.props.saveState === 'success'
+      this.props.saveState === 'complete'
     ) {
       allSubmissionsComplete = true;
     }

--- a/src/account-settings/coaching/CoachingToggle.jsx
+++ b/src/account-settings/coaching/CoachingToggle.jsx
@@ -5,7 +5,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { ValidationFormGroup, Input } from '@edx/paragon';
 import messages from './CoachingToggle.messages';
 import { editableFieldSelector } from '../data/selectors';
-import { saveSettings, updateDraft } from '../data/actions';
+import { saveSettings, updateDraft, saveMultipleSettings } from '../data/actions';
 import EditableField from '../EditableField';
 
 
@@ -18,7 +18,25 @@ const CoachingToggle = props => (
       label={props.intl.formatMessage(messages['account.settings.field.phone_number'])}
       emptyLabel={props.intl.formatMessage(messages['account.settings.field.phone_number.empty'])}
       onChange={props.updateDraft}
-      onSubmit={props.saveSettings}
+      onSubmit={() => {
+        const { coaching } = props;
+        if (coaching.coaching_consent === true) {
+          return props.saveMultipleSettings([
+            {
+              formId: 'coaching',
+              commitValues: {
+                ...coaching,
+                phone_number: props.phone_number,
+              },
+            },
+            {
+              formId: 'phone_number',
+              commitValues: props.phone_number,
+            },
+        ]);
+      }
+        return props.saveSettings('phone_number', props.phone_number);
+    }}
     />
     <ValidationFormGroup
       for="coachingConsent"
@@ -68,6 +86,7 @@ CoachingToggle.propTypes = {
   }).isRequired,
   saveState: PropTypes.oneOf(['default', 'pending', 'complete', 'error']),
   saveSettings: PropTypes.func.isRequired,
+  saveMultipleSettings: PropTypes.func.isRequired,
   updateDraft: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   phone_number: PropTypes.string,
@@ -76,4 +95,5 @@ CoachingToggle.propTypes = {
 export default connect(editableFieldSelector, {
   saveSettings,
   updateDraft,
+  saveMultipleSettings,
 })(injectIntl(CoachingToggle));

--- a/src/account-settings/data/reducers.js
+++ b/src/account-settings/data/reducers.js
@@ -154,7 +154,7 @@ const reducer = (state = defaultState, action) => {
     case SAVE_MULTIPLE_SETTINGS.SUCCESS:
       return {
         ...state,
-        saveState: 'success',
+        saveState: 'complete',
       };
 
     case SAVE_MULTIPLE_SETTINGS.FAILURE:

--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -115,8 +115,7 @@ export function* handleSaveMultipleSettings(settings) {
       const { formId, commitValues } = settingsArray[i];
       yield put(saveSettingsBegin());
       const commitData = { [formId]: commitValues };
-      let savedSettings = commitData;
-      savedSettings = yield call(patchSettings, username, commitData, userId);
+      const savedSettings = yield call(patchSettings, username, commitData, userId);
       yield put(saveSettingsSuccess(savedSettings, commitData));
     }
     yield put(saveMultipleSettingsSuccess(settings));

--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -113,7 +113,11 @@ export function* handleSaveMultipleSettings(settings) {
     const { settingsArray } = settings.payload;
     for (let i = 0; i < settingsArray.length; i += 1) {
       const { formId, commitValues } = settingsArray[i];
-      yield call(patchSettings, username, { [formId]: commitValues }, userId);
+      yield put(saveSettingsBegin());
+      const commitData = { [formId]: commitValues };
+      let savedSettings = commitData;
+      savedSettings = yield call(patchSettings, username, commitData, userId);
+      yield put(saveSettingsSuccess(savedSettings, commitData));
     }
     yield put(saveMultipleSettingsSuccess(settings));
   } catch (e) {

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -183,7 +183,7 @@ export async function patchSettings(username, commitValues, userId) {
   // user/v1/preferences where it does update. This is the one we use.
   const preferenceKeys = ['time_zone'];
   const coachingKeys = ['coaching'];
-  const accountCommitValues = omit(commitValues, preferenceKeys);
+  const accountCommitValues = omit(commitValues, preferenceKeys, coachingKeys);
   const preferenceCommitValues = pick(commitValues, preferenceKeys);
   const coachingCommitValues = pick(commitValues, coachingKeys);
   const patchRequests = [];


### PR DESCRIPTION
This fixes a few little bugs in the system as well as the one listed in
the ticket.

* We no longer make an extra API call to user profile when toggling
coaching
* The user now must toggle coaching off to save a non-eligible phone
number
* If the user changes to another US based phone number, or is not
consented to coaching, the phone number will save as normal.

* SAVE_MULTIPLE_SETTINGS now leverages the SAVE_SETTINGS action for a full redux log and a synchronous execution.

* coaching toggled on by default in dev