### PR TITLE
MB-17: Refactor coaching_consent form

### DIFF
--- a/src/account-settings/coaching/CoachingConsentForm.jsx
+++ b/src/account-settings/coaching/CoachingConsentForm.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Input, Button, Hyperlink } from '@edx/paragon';
 
@@ -38,7 +37,7 @@ const CoachingForm = props => (
             !!props.profileDataManager &&
             <ManagedProfileAlert profileDataManager={props.profileDataManager} />
           }
-          <ErrorMessage message={props.formErrors.name} />
+          <ErrorMessage message={props.formErrors.full_name} />
           <label className="h6" htmlFor="fullName">{props.intl.formatMessage(messages['account.settings.coaching.consent.label.name'])}</label>
           <Input
             type="text"
@@ -53,7 +52,7 @@ const CoachingForm = props => (
           <label className="h6" htmlFor="phoneNumber">{props.intl.formatMessage(messages['account.settings.coaching.consent.label.phone-number'])}</label>
           <Input
             type="text"
-            name="full-name"
+            name="phone_number"
             id="phoneNumber"
             defaultValue={props.formValues.phone_number}
           />
@@ -107,7 +106,7 @@ CoachingForm.propTypes = {
   }).isRequired,
   formErrors: PropTypes.shape({
     coaching: PropTypes.string,
-    name: PropTypes.string,
+    full_name: PropTypes.string,
     phone_number: PropTypes.string,
   }),
   redirectUrl: PropTypes.string.isRequired,

--- a/src/account-settings/coaching/test/CoachingConsent.test.jsx
+++ b/src/account-settings/coaching/test/CoachingConsent.test.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import renderer from 'react-test-renderer';
+import { act } from 'react-dom/test-utils';
+import configureStore from 'redux-mock-store';
+import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+import * as auth from '@edx/frontend-platform/auth';
+
+import CoachingConsent from '../CoachingConsent';
+import * as selectors from '../../data/selectors';
+
+jest.mock('@edx/frontend-platform/auth');
+
+const IntlCoachingConsent = injectIntl(CoachingConsent);
+
+jest.mock('../../data/selectors', () => {
+  return jest.fn().mockImplementation(() => ({ coachingConsentPageSelector: () => ({}) }));
+});
+
+const mockStore = configureStore();
+
+describe('CoachingConsent', () => {
+  let props = {};
+  let store = {};
+  selectors.mockClear();
+
+  const reduxWrapper = children => (
+    <IntlProvider locale="en">
+      <Provider store={store}>{children}</Provider>
+    </IntlProvider>
+  );
+
+  beforeEach(() => {
+    store = mockStore();
+    props = {
+      fetchSettings: jest.fn(),
+      loaded: true,
+      saveState: undefined,
+      formValues: {
+        name: 'edx edx',
+        phone_number: '1234567890',
+        coaching: {
+          coaching_consent: true,
+          consent_form_seen: false,
+          eligible_for_coaching: true,
+          user: 1,
+        },
+      },
+      formErrors: {},
+      confirmationValues: {},
+      profileDataManager: '',
+      intl: {},
+    };
+    auth.getAuthenticatedHttpClient = jest.fn(() => ({
+      patch: async () => ({
+        data: { status: 200 },
+        catch: () => {},
+      }),
+    }));
+    auth.getAuthenticatedUser = jest.fn(() => ({ userId: 3 }));
+  });
+
+  it('should render', () => {
+    const wrapper = renderer.create(reduxWrapper(<IntlCoachingConsent {...props} />)).toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('disables name field on enterprise user', () => {
+    props = {
+      ...props,
+      profileDataManager: 'test person',
+    };
+    const wrapper = renderer.create(reduxWrapper(<IntlCoachingConsent {...props} />)).toJSON();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('display completed box when successfully submitted', async () => {
+    const fakeEvent = {
+      preventDefault: () => {},
+      target: {
+        fullName: { value: 'edx edx' },
+        phoneNumber: { value: '9783028731' },
+      },
+    };
+    const wrapper = renderer.create(
+      reduxWrapper(<IntlCoachingConsent {...props} />),
+      {
+        // bypass the forward-ref. we don't care about focus for this one test
+        createNodeMock: (element) => {
+          if (element.type === 'button') {
+            // mock a focus function
+            return {
+              focus: async () => wrapper.root.findByType('form').props.onSubmit(fakeEvent),
+            };
+          }
+          return null;
+        },
+      },
+    );
+    const form = wrapper.root.findByType('form');
+    await act(async () => { await form.props.onSubmit(fakeEvent); });
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/account-settings/coaching/test/__snapshots__/CoachingConsent.test.jsx.snap
+++ b/src/account-settings/coaching/test/__snapshots__/CoachingConsent.test.jsx.snap
@@ -1,0 +1,282 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CoachingConsent disables name field on enterprise user 1`] = `
+<main>
+  <div
+    className="w-100 d-flex justify-content-center align-items-center shadow coaching-header"
+  >
+    <img
+      alt="Logo"
+      className="logo"
+      src="icon/mock/path"
+    />
+  </div>
+  <div
+    className="col-12 col-md-6 col-xl-5 mx-auto mt-4 p-5 shadow-lg"
+  >
+    <h2
+      className="h2"
+    >
+      Let’s get started.
+    </h2>
+    <p>
+      MicroBachelors programs include coaching that focuses on your career, education, and how you'll achieve results through one-on-one communication with an experienced professional. If you’re interested, provide the information below and click “Submit,” and our coaching partner will connect with you via email and/or text message to help you move forward. Terms and conditions apply.*
+    </p>
+    <div>
+      <form
+        onSubmit={[Function]}
+      >
+        <div
+          className="py-3"
+        >
+          <div
+            className="alert d-flex align-items-start alert alert-primary"
+          >
+            <div />
+            <div>
+              <span>
+                Your name is managed by 
+                <b>
+                  test person
+                </b>
+                . Contact your administrator for help.
+              </span>
+            </div>
+          </div>
+          <div
+            className="alert-warning mb-2"
+          >
+            
+          </div>
+          <label
+            className="h6"
+            htmlFor="fullName"
+          >
+            Please confirm your name
+          </label>
+          <input
+            className="form-control"
+            defaultValue="edx edx"
+            disabled={true}
+            id="fullName"
+            name="full-name"
+            type="text"
+          />
+        </div>
+        <div
+          className="py-3"
+        >
+          <div
+            className="alert-warning mb-2"
+          >
+            
+          </div>
+          <label
+            className="h6"
+            htmlFor="phoneNumber"
+          >
+            Enter your mobile number
+          </label>
+          <input
+            className="form-control"
+            defaultValue="1234567890"
+            id="phoneNumber"
+            name="phone_number"
+            type="text"
+          />
+        </div>
+        <div
+          className=" py-3"
+        >
+          <p
+            className="small font-italic"
+          >
+            * Coaching services are included at no additional cost to learners with US phone numbers. Coaching includes recurring text messages. Message and data rates may apply. Text STOP to opt-out.
+          </p>
+        </div>
+        <div
+          className="alert-warning mb-2"
+        >
+          
+        </div>
+        <div
+          className="d-flex flex-column align-items-center"
+        >
+          <button
+            className="btn w-100 btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="submit"
+          >
+            Sign up for coaching
+          </button>
+        </div>
+        <div
+          className="mt-3"
+        >
+          <a
+            className="mt-3 text-dark btn-link small"
+            href="http://localhost:18000/dashboard/"
+            onClick={[Function]}
+            target="_self"
+          >
+            I prefer not to be contacted with free coaching services
+          </a>
+        </div>
+      </form>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`CoachingConsent display completed box when successfully submitted 1`] = `
+<main>
+  <div
+    className="w-100 d-flex justify-content-center align-items-center shadow coaching-header"
+  >
+    <img
+      alt="Logo"
+      className="logo"
+      src="icon/mock/path"
+    />
+  </div>
+  <div>
+    <div
+      className="d-flex justify-content-center align-items-center flex-column"
+      style={
+        Object {
+          "height": "50vh",
+        }
+      }
+    >
+      <div
+        className="spinner-border text-primary"
+        role="status"
+      >
+        <span
+          className="sr-only"
+        >
+          Submitting...
+        </span>
+      </div>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`CoachingConsent should render 1`] = `
+<main>
+  <div
+    className="w-100 d-flex justify-content-center align-items-center shadow coaching-header"
+  >
+    <img
+      alt="Logo"
+      className="logo"
+      src="icon/mock/path"
+    />
+  </div>
+  <div
+    className="col-12 col-md-6 col-xl-5 mx-auto mt-4 p-5 shadow-lg"
+  >
+    <h2
+      className="h2"
+    >
+      Let’s get started.
+    </h2>
+    <p>
+      MicroBachelors programs include coaching that focuses on your career, education, and how you'll achieve results through one-on-one communication with an experienced professional. If you’re interested, provide the information below and click “Submit,” and our coaching partner will connect with you via email and/or text message to help you move forward. Terms and conditions apply.*
+    </p>
+    <div>
+      <form
+        onSubmit={[Function]}
+      >
+        <div
+          className="py-3"
+        >
+          <div
+            className="alert-warning mb-2"
+          >
+            
+          </div>
+          <label
+            className="h6"
+            htmlFor="fullName"
+          >
+            Please confirm your name
+          </label>
+          <input
+            className="form-control"
+            defaultValue="edx edx"
+            disabled={false}
+            id="fullName"
+            name="full-name"
+            type="text"
+          />
+        </div>
+        <div
+          className="py-3"
+        >
+          <div
+            className="alert-warning mb-2"
+          >
+            
+          </div>
+          <label
+            className="h6"
+            htmlFor="phoneNumber"
+          >
+            Enter your mobile number
+          </label>
+          <input
+            className="form-control"
+            defaultValue="1234567890"
+            id="phoneNumber"
+            name="phone_number"
+            type="text"
+          />
+        </div>
+        <div
+          className=" py-3"
+        >
+          <p
+            className="small font-italic"
+          >
+            * Coaching services are included at no additional cost to learners with US phone numbers. Coaching includes recurring text messages. Message and data rates may apply. Text STOP to opt-out.
+          </p>
+        </div>
+        <div
+          className="alert-warning mb-2"
+        >
+          
+        </div>
+        <div
+          className="d-flex flex-column align-items-center"
+        >
+          <button
+            className="btn w-100 btn-outline-primary"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="submit"
+          >
+            Sign up for coaching
+          </button>
+        </div>
+        <div
+          className="mt-3"
+        >
+          <a
+            className="mt-3 text-dark btn-link small"
+            href="http://localhost:18000/dashboard/"
+            onClick={[Function]}
+            target="_self"
+          >
+            I prefer not to be contacted with free coaching services
+          </a>
+        </div>
+      </form>
+    </div>
+  </div>
+</main>
+`;


### PR DESCRIPTION
We were having issues with how the coaching consent form was sending
data. Previously, we were hitting 2 endpoints - one from the coaching
plugin, and one from the LMS. This changes fixes a few issues:

* CoachingConsent now hits one api that handles saving the phone_number,
full_name, and coaching_consent.
* This component does not need to share any of this data, so it is not
connected to Redux. Everything to do with patching is done in the
CoachingConsent component.
* Fetching data is still done through actions provided by redux.
* This change does not effect the fields in the root account settings
page
* Also fixes an issue where the 404 error message was showing up at the
bottom of every page.