### PR TITLE
ID Verification: Hide image upload component

### DIFF
--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -121,6 +121,11 @@ const messages = defineMessages({
     defaultMessage: 'It looks like we\'re unable to access your camera. You will need to upload image files of you and your photo id.',
     description: 'Text indicating that the camera could not be accessed and image upload will be enabled.',
   },
+  'id.verification.camera.access.failure.temporary': {
+    id: 'id.verification.camera.access.failure.temporary',
+    defaultMessage: 'It looks like we\'re unable to access your camera. Please verify that your webcam is connected and that you have allowed your browser to access it.',
+    description: 'Text indicating that the camera could not be accessed.',
+  },
   'id.verification.photo.tips.title': {
     id: 'id.verification.photo.tips.title',
     defaultMessage: 'Helpful Photo Tips',

--- a/src/id-verification/panels/RequestCameraAccessPanel.jsx
+++ b/src/id-verification/panels/RequestCameraAccessPanel.jsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { Collapsible } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { useNextPanelSlug } from '../routing-utilities';
@@ -10,9 +10,20 @@ import { IdVerificationContext, MEDIA_ACCESS } from '../IdVerificationContext';
 import messages from '../IdVerification.messages';
 
 function RequestCameraAccessPanel(props) {
+  const [returnUrl, setReturnUrl] = useState('dashboard');
+  const [returnText, setReturnText] = useState('id.verification.return.dashboard');
   const panelSlug = 'request-camera-access';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
   const { tryGetUserMedia, mediaAccess } = useContext(IdVerificationContext);
+
+  // If the user accessed IDV through a course,
+  // link back to that course rather than the dashboard
+  useEffect(() => {
+    if (sessionStorage.getItem('courseRunKey')) {
+      setReturnUrl(`courses/${sessionStorage.getItem('courseRunKey')}`);
+      setReturnText('id.verification.return.course');
+    }
+  }, []);
 
   return (
     <BasePanel
@@ -35,18 +46,6 @@ function RequestCameraAccessPanel(props) {
             <button className="btn btn-primary" onClick={tryGetUserMedia}>
               {props.intl.formatMessage(messages['id.verification.camera.access.enable'])}
             </button>
-            <Collapsible.Advanced className="mr-auto">
-              <Collapsible.Visible whenClosed>
-                <Collapsible.Trigger tag="button" className="btn btn-link px-0">
-                  {props.intl.formatMessage(messages['id.verification.camera.access.problems'])}
-                </Collapsible.Trigger>
-              </Collapsible.Visible>
-              <Collapsible.Body>
-                <Link to={nextPanelSlug} className="btn btn-link">
-                  {props.intl.formatMessage(messages['id.verification.camera.access.skip'])}
-                </Link>
-              </Collapsible.Body>
-            </Collapsible.Advanced>
           </div>
         </div>
       )}
@@ -67,12 +66,12 @@ function RequestCameraAccessPanel(props) {
       {[MEDIA_ACCESS.UNSUPPORTED, MEDIA_ACCESS.DENIED].includes(mediaAccess) && (
         <div>
           <p>
-            {props.intl.formatMessage(messages['id.verification.camera.access.failure'])}
+            {props.intl.formatMessage(messages['id.verification.camera.access.failure.temporary'])}
           </p>
           <div className="action-row">
-            <Link to={nextPanelSlug} className="btn btn-primary">
-              {props.intl.formatMessage(messages['id.verification.next'])}
-            </Link>
+            <a className="btn btn-primary" href={`${getConfig().LMS_BASE_URL}/${returnUrl}`}>
+              {props.intl.formatMessage(messages[returnText])}
+            </a>
           </div>
         </div>
       )}

--- a/src/id-verification/panels/TakeIdPhotoPanel.jsx
+++ b/src/id-verification/panels/TakeIdPhotoPanel.jsx
@@ -8,15 +8,18 @@ import ImageFileUpload from '../ImageFileUpload';
 import ImagePreview from '../ImagePreview';
 import Camera from '../Camera';
 import CameraHelp from '../CameraHelp';
-import { IdVerificationContext, MEDIA_ACCESS } from '../IdVerificationContext';
+import { IdVerificationContext } from '../IdVerificationContext';
 
 import messages from '../IdVerification.messages';
 
 function TakeIdPhotoPanel(props) {
   const panelSlug = 'take-id-photo';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
-  const { setIdPhotoFile, idPhotoFile, mediaAccess } = useContext(IdVerificationContext);
-  const shouldUseCamera = mediaAccess === MEDIA_ACCESS.GRANTED;
+  const { setIdPhotoFile, idPhotoFile } = useContext(IdVerificationContext);
+  const shouldUseCamera = true;
+  // to reenable upload component:
+  // const shouldUseCamera = mediaAccess === MEDIA_ACCESS.GRANTED;
+
   return (
     <BasePanel
       name={panelSlug}

--- a/src/id-verification/panels/TakePortraitPhotoPanel.jsx
+++ b/src/id-verification/panels/TakePortraitPhotoPanel.jsx
@@ -8,15 +8,17 @@ import ImageFileUpload from '../ImageFileUpload';
 import ImagePreview from '../ImagePreview';
 import Camera from '../Camera';
 import CameraHelp from '../CameraHelp';
-import { IdVerificationContext, MEDIA_ACCESS } from '../IdVerificationContext';
+import { IdVerificationContext } from '../IdVerificationContext';
 
 import messages from '../IdVerification.messages';
 
 function TakePortraitPhotoPanel(props) {
   const panelSlug = 'take-portrait-photo';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
-  const { setFacePhotoFile, facePhotoFile, mediaAccess } = useContext(IdVerificationContext);
-  const shouldUseCamera = mediaAccess === MEDIA_ACCESS.GRANTED;
+  const { setFacePhotoFile, facePhotoFile } = useContext(IdVerificationContext);
+  const shouldUseCamera = true;
+  // to reenable upload component:
+  // const shouldUseCamera = mediaAccess === MEDIA_ACCESS.GRANTED;
 
   return (
     <BasePanel


### PR DESCRIPTION
[MST-326](https://openedx.atlassian.net/browse/MST-326)

Temporary removal of image upload component from IDV flow. This component may be reimplemented at a later date with modifications.

- Camera access is required to successfully complete the process.
- If the user blocks camera access or camera access is otherwise unavailable, they will receive an error message and a button to return to the dashboard or course, depending on where they entered the IDV flow from.

----

![Screen Shot 2020-07-17 at 1 23 36 PM](https://user-images.githubusercontent.com/10442143/87813893-c2c69100-c830-11ea-8d39-d44340f9c292.png)
