### PR TITLE
MICROBA-463 Collapse phone number field when coaching toggled on

### DIFF
--- a/src/account-settings/coaching/CoachingToggle.jsx
+++ b/src/account-settings/coaching/CoachingToggle.jsx
@@ -33,7 +33,7 @@ const CoachingToggle = props => (
               formId: 'phone_number',
               commitValues: props.phone_number,
             },
-        ]);
+        ], 'phone_number');
       }
         return props.saveSettings('phone_number', props.phone_number);
     }}


### PR DESCRIPTION
This change passes the ID of the form we want to close to the `saveMultipleSettings` action, allowing it to close when the call comes back successfully. ([See these lines in the the saga.](https://github.com/edx/frontend-app-account/blob/0196245c13b820f2a8643efab08c4fd172196486/src/account-settings/data/sagas.js#L122-L125))

Previously, the phone number field would not close while coaching was toggled on:
https://www.loom.com/share/31557612cecb4acfa63d9bfa30979095

Now it does:
https://www.loom.com/share/cc2f4b8e7b25404ca2628f7b7baaae00

MICROBA-463