### PR TITLE
MICROBA-487 Fix legal text spacing on demographics section

### DIFF
--- a/src/account-settings/demographics/DemographicsSection.jsx
+++ b/src/account-settings/demographics/DemographicsSection.jsx
@@ -170,12 +170,12 @@ class DemographicsSection extends React.Component {
         <h2 className="section-heading">
           {this.props.intl.formatMessage(messages['account.settings.section.demographics.information'])}
         </h2>
-        <div className="mb-2">
+        <p>
           <a href={getConfig().MARKETING_SITE_BASE_URL + '/demographics'} target="_blank">
             {this.props.intl.formatMessage(messages['account.settings.section.demographics.why'])}
           </a>
-          {this.renderDemographicsServiceIssueWarning()}
-        </div>
+        </p>
+        {this.renderDemographicsServiceIssueWarning()}
 
         <EditableField
           name="demographics_gender"

--- a/src/account-settings/demographics/test/__snapshots__/DemographicsSection.test.jsx.snap
+++ b/src/account-settings/demographics/test/__snapshots__/DemographicsSection.test.jsx.snap
@@ -10,16 +10,14 @@ exports[`DemographicsSection should render 1`] = `
   >
     Optional Information
   </h2>
-  <div
-    className="mb-2"
-  >
+  <p>
     <a
       href="http://localhost:5335/demographics"
       target="_blank"
     >
       Why does edX collect this information?
     </a>
-  </div>
+  </p>
   <div
     className="pgn-transition-replace-group position-relative"
     style={
@@ -599,27 +597,25 @@ exports[`DemographicsSection should render an Alert if an error occurs 1`] = `
   >
     Optional Information
   </h2>
-  <div
-    className="mb-2"
-  >
+  <p>
     <a
       href="http://localhost:5335/demographics"
       target="_blank"
     >
       Why does edX collect this information?
     </a>
+  </p>
+  <div
+    tabIndex="-1"
+  >
     <div
-      tabIndex="-1"
+      className="alert d-flex align-items-start alert alert-danger"
     >
-      <div
-        className="alert d-flex align-items-start alert alert-danger"
-      >
-        <div />
-        <div>
-          <span>
-            An error occurred attempting to retrieve or save your account information. Please try again later.
-          </span>
-        </div>
+      <div />
+      <div>
+        <span>
+          An error occurred attempting to retrieve or save your account information. Please try again later.
+        </span>
       </div>
     </div>
   </div>
@@ -1202,16 +1198,14 @@ exports[`DemographicsSection should render ethnicity correctly when multiple opt
   >
     Optional Information
   </h2>
-  <div
-    className="mb-2"
-  >
+  <p>
     <a
       href="http://localhost:5335/demographics"
       target="_blank"
     >
       Why does edX collect this information?
     </a>
-  </div>
+  </p>
   <div
     className="pgn-transition-replace-group position-relative"
     style={
@@ -1847,16 +1841,14 @@ exports[`DemographicsSection should render ethnicity text correctly 1`] = `
   >
     Optional Information
   </h2>
-  <div
-    className="mb-2"
-  >
+  <p>
     <a
       href="http://localhost:5335/demographics"
       target="_blank"
     >
       Why does edX collect this information?
     </a>
-  </div>
+  </p>
   <div
     className="pgn-transition-replace-group position-relative"
     style={
@@ -2492,16 +2484,14 @@ exports[`DemographicsSection should set user input correctly when user provides 
   >
     Optional Information
   </h2>
-  <div
-    className="mb-2"
-  >
+  <p>
     <a
       href="http://localhost:5335/demographics"
       target="_blank"
     >
       Why does edX collect this information?
     </a>
-  </div>
+  </p>
   <div
     className="pgn-transition-replace-group position-relative"
     style={
@@ -3137,16 +3127,14 @@ exports[`DemographicsSection should set user input correctly when user provides 
   >
     Optional Information
   </h2>
-  <div
-    className="mb-2"
-  >
+  <p>
     <a
       href="http://localhost:5335/demographics"
       target="_blank"
     >
       Why does edX collect this information?
     </a>
-  </div>
+  </p>
   <div
     className="pgn-transition-replace-group position-relative"
     style={


### PR DESCRIPTION
This PR makes the `Why does edX collect this information?` link follow the same styling as helper text in other sections. (The "`Optionally, link your personal accounts to the social media icons on your edX profile`" text in the Social Media Links section.)

Now:
<img width="1904" alt="Screen Shot 2020-07-21 at 3 10 55 PM" src="https://user-images.githubusercontent.com/26205183/88096690-1274c780-cb65-11ea-9d9d-dc003dcfd97f.png">

Compare to the Social Media Links section:
<img width="1904" alt="Screen Shot 2020-07-21 at 3 11 03 PM" src="https://user-images.githubusercontent.com/26205183/88096723-20c2e380-cb65-11ea-90e4-94f7e97fd953.png">

And (just in case) what spacing looks like with the error displayed:
<img width="1904" alt="Screen Shot 2020-07-21 at 3 11 32 PM" src="https://user-images.githubusercontent.com/26205183/88096762-2f10ff80-cb65-11ea-819e-013092879847.png">

MICROBA-487