### PR TITLE
Add i18n and UX improvements to IDV

### DIFF
--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -67,7 +67,11 @@ class Camera extends React.Component {
           />
         </div>
         <button
-          className='btn btn-primary camera-btn'
+          className={`btn camera-btn ${
+            this.state.dataUri ?
+              'btn-outline-primary'
+              : 'btn-primary'
+          }`}
           accessKey='c'
           onClick={() => {
             this.takePhoto();

--- a/src/id-verification/ExistingRequest.jsx
+++ b/src/id-verification/ExistingRequest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { getConfig } from '@edx/frontend-platform';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import messages from './IdVerification.messages';
 
@@ -10,13 +10,22 @@ function ExistingRequest(props) {
       <h3 aria-level="1" tabIndex="-1">
         {props.intl.formatMessage(messages['id.verification.existing.request.title'])}
       </h3>
-      {props.status === 'pending' || props.status == 'approved'
+      {props.status === 'pending' || props.status === 'approved'
         ? <p>{props.intl.formatMessage(messages['id.verification.existing.request.pending.text'])}</p>
-        : <p>{props.intl.formatMessage(messages['id.verification.existing.request.denied.text'])}</p>
+        : <FormattedMessage
+          id="id.verification.existing.request.denied.text"
+          defaultMessage="You cannot verify your identity at this time. If you have yet to activate your account, please check your spam folder for the activation email from {email}."
+          description="Text that displays when user is denied from making a request, and to check their email for an activation email."
+          values={{
+            email: <strong>no-reply@registration.edx.org</strong>,
+          }}
+        />
         }
-      <a className="btn btn-primary" href={`${getConfig().LMS_BASE_URL}/dashboard`}>
-        {props.intl.formatMessage(messages['id.verification.return'])}
-      </a>
+      <div className="action-row">
+        <a className="btn btn-primary mt-3" href={`${getConfig().LMS_BASE_URL}/dashboard`}>
+          {props.intl.formatMessage(messages['id.verification.return.dashboard'])}
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -68,13 +68,8 @@ const messages = defineMessages({
   },
   'id.verification.existing.request.pending.text': {
     id: 'id.verification.existing.request.pending.text',
-    defaultMessage: 'You have already submitted your verification information. You will see a message on your dashboard when the verification process is complete (usually within 1-2 days).',
+    defaultMessage: 'You have already submitted your verification information. You will see a message on your dashboard when the verification process is complete (usually within 5 days).',
     description: 'Text that displays when user has a pending or approved request.',
-  },
-  'id.verification.existing.request.denied.text': {
-    id: 'id.verification.existing.request.denied.text',
-    defaultMessage: 'You cannot verify your identity at this time.',
-    description: 'Text that displays when user is denied from making a request.',
   },
   'id.verification.photo.take': {
     id: 'id.verification.photo.take',
@@ -90,6 +85,16 @@ const messages = defineMessages({
     id: 'id.verification.camera.access.title',
     defaultMessage: 'Camera Permissions',
     description: 'Title for the Camera Access page.',
+  },
+  'id.verification.camera.access.title.success': {
+    id: 'id.verification.camera.access.title.success',
+    defaultMessage: 'Camera Access Enabled',
+    description: 'Title for the Camera Access page when camera is enabled.',
+  },
+  'id.verification.camera.access.title.failed': {
+    id: 'id.verification.camera.access.title.failed',
+    defaultMessage: 'Camera Access Failed',
+    description: 'Title for the Camera Access page when camera access is denied or unavailable.',
   },
   'id.verification.camera.access.click.allow': {
     id: 'id.verification.camera.access.click.allow',
@@ -158,12 +163,12 @@ const messages = defineMessages({
   },
   'id.verification.portrait.photo.title.camera': {
     id: 'id.verification.portrait.photo.title.camera',
-    defaultMessage: 'Take Your Photo',
+    defaultMessage: 'Take a Photo of Yourself',
     description: 'Title for the Portrait Photo page if camera access is enabled.',
   },
   'id.verification.portrait.photo.title.upload': {
     id: 'id.verification.portrait.photo.title.upload',
-    defaultMessage: 'Upload Your Portrait Photo',
+    defaultMessage: 'Upload a Photo of Yourself',
     description: 'Title for the Portrait Photo page if camera access is disabled.',
   },
   'id.verification.portrait.photo.preview.alt': {
@@ -208,7 +213,7 @@ const messages = defineMessages({
   },
   'id.verification.id.tips.description': {
     id: 'id.verification.id.tips.description',
-    defaultMessage: 'Next you\'ll need an eligible ID photo, make sure that:',
+    defaultMessage: 'Next, we\'ll need you to take a photo of a valid ID that includes your name. Please have your ID ready. Make sure that:',
     description: 'Description for the ID Tips page.',
   },
   'id.verification.id.tips.list.well.lit': {
@@ -223,12 +228,12 @@ const messages = defineMessages({
   },
   'id.verification.id.photo.title.camera': {
     id: 'id.verification.id.photo.title.camera',
-    defaultMessage: 'Take ID Photo',
+    defaultMessage: 'Take a Photo of Your ID',
     description: 'Title for the ID Photo page if camera access is enabled.',
   },
   'id.verification.id.photo.title.upload': {
     id: 'id.verification.id.photo.title.upload',
-    defaultMessage: 'Upload Your ID Photo',
+    defaultMessage: 'Upload a Photo of Your ID',
     description: 'Title for the ID Photo page if camera access is disabled.',
   },
   'id.verification.id.photo.preview.alt': {
@@ -253,8 +258,28 @@ const messages = defineMessages({
   },
   'id.verification.account.name.instructions': {
     id: 'id.verification.account.name.instructions',
-    defaultMessage: 'Please check the Account Name below to ensure it matches the name on your ID. If not, click "Edit".',
+    defaultMessage: 'The name on your account and the name on your ID must be an exact match. If not, please click "No" to update your account name.',
     description: 'Text to verify that the account name matches the name on the ID photo.',
+  },
+  'id.verification.account.name.radio.label': {
+    id: 'id.verification.account.name.radio.label',
+    defaultMessage: 'Does the name on your ID match the Account Name below?',
+    description: 'Question to ask the user whether their account name match the name on their ID card.',
+  },
+  'id.verification.account.name.radio.yes': {
+    id: 'id.verification.account.name.radio.yes',
+    defaultMessage: 'Yes',
+    description: 'The radio button that says the account name matches.',
+  },
+  'id.verification.account.name.radio.no': {
+    id: 'id.verification.account.name.radio.no',
+    defaultMessage: 'No',
+    description: 'The radio button that says the account name does not match.',
+  },
+  'id.verification.account.name.error': {
+    id: 'id.verification.account.name.error',
+    defaultMessage: 'Please update account name to match the name on your ID.',
+    description: 'Error that shows when the user needs to update their account name to match the name on their ID.',
   },
   'id.verification.account.name.warning.prefix': {
     id: 'id.verification.account.name.warning.prefix',
@@ -268,7 +293,7 @@ const messages = defineMessages({
   },
   'id.verification.account.name.label': {
     id: 'id.verification.account.name.label',
-    defaultMessage: 'Name on ID',
+    defaultMessage: 'Account Name',
     description: 'Label for account name input.',
   },
   'id.verification.account.name.edit': {
@@ -283,7 +308,7 @@ const messages = defineMessages({
   },
   'id.verification.account.name.save': {
     id: 'id.verification.account.name.save',
-    defaultMessage: 'Save',
+    defaultMessage: 'Save and Next',
     description: 'Button to save the account name.',
   },
   'id.verification.review.title': {
@@ -328,8 +353,8 @@ const messages = defineMessages({
   },
   'id.verification.review.confirm': {
     id: 'id.verification.review.confirm',
-    defaultMessage: 'Confirm',
-    description: 'Button to confirm all information is correct.',
+    defaultMessage: 'Submit',
+    description: 'Button to confirm all information is correct and submit.',
   },
   'id.verification.submitted.title': {
     id: 'id.verification.submitted.title',

--- a/src/id-verification/_id-verification.scss
+++ b/src/id-verification/_id-verification.scss
@@ -12,6 +12,14 @@
         max-height: 10rem;
       }
     }
+    .form-check {
+      padding: 0.5rem 0.5rem 1rem;      
+      .form-check-label {
+        margin-left: 0.5rem;
+        padding-top: 0.2rem;
+        font-weight: normal;
+      }
+    }
   }
   .action-row {
     display: flex;

--- a/src/id-verification/panels/RequestCameraAccessPanel.jsx
+++ b/src/id-verification/panels/RequestCameraAccessPanel.jsx
@@ -41,10 +41,19 @@ function RequestCameraAccessPanel(props) {
     }
   }, []);
 
+  const getTitle = () => {
+    if (mediaAccess === MEDIA_ACCESS.GRANTED) {
+      return props.intl.formatMessage(messages['id.verification.camera.access.title.success']);
+    } else if ([MEDIA_ACCESS.UNSUPPORTED, MEDIA_ACCESS.DENIED].includes(mediaAccess)) {
+      return props.intl.formatMessage(messages['id.verification.camera.access.title.failed']);
+    }
+    return props.intl.formatMessage(messages['id.verification.camera.access.title']);
+  };
+
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.camera.access.title'])}
+      title={getTitle()}
     >
       {mediaAccess === MEDIA_ACCESS.PENDING && (
         <div>

--- a/src/id-verification/panels/ReviewRequirementsPanel.jsx
+++ b/src/id-verification/panels/ReviewRequirementsPanel.jsx
@@ -32,7 +32,7 @@ function ReviewRequirementsPanel(props) {
       </p>
       <div className="card mb-4 shadow requirements">
         <div className="card-body">
-          <h6>
+          <h6 aria-level="3">
             {props.intl.formatMessage(messages['id.verification.requirements.card.device.title'])}
           </h6>
           <p className="mb-0">
@@ -49,7 +49,7 @@ function ReviewRequirementsPanel(props) {
       </div>
       <div className="card mb-4 shadow requirements">
         <div className="card-body">
-          <h6>
+          <h6 aria-level="3">
             {props.intl.formatMessage(messages['id.verification.requirements.card.id.title'])}
           </h6>
           <p className="mb-0">
@@ -57,16 +57,16 @@ function ReviewRequirementsPanel(props) {
           </p>
         </div>
       </div>
-      <h4 className="mb-3">
+      <h4 aria-level="2" className="mb-3">
         {props.intl.formatMessage(messages['id.verification.privacy.title'])}
       </h4>
-      <h6>
+      <h6 aria-level="3">
         {props.intl.formatMessage(messages['id.verification.privacy.need.photo.question'])}
       </h6>
       <p>
         {props.intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}
       </p>
-      <h6>
+      <h6 aria-level="3">
         {props.intl.formatMessage(messages['id.verification.privacy.do.with.photo.question'])}
       </h6>
       <p>

--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -70,7 +70,7 @@ function SummaryPanel(props) {
             alt={props.intl.formatMessage(messages['id.verification.review.portrait.alt'])}
           />
           <Link
-            className="btn btn-inverse-primary shadow"
+            className="btn btn-outline-primary"
             to={{
               pathname: 'take-portrait-photo',
               state: { fromSummary: true },
@@ -89,7 +89,7 @@ function SummaryPanel(props) {
             alt={props.intl.formatMessage(messages['id.verification.review.id.alt'])}
           />
           <Link
-            className="btn btn-inverse-primary shadow"
+            className="btn btn-outline-primary"
             to={{
               pathname: 'take-id-photo',
               state: { fromSummary: true },

--- a/src/id-verification/panels/TakeIdPhotoPanel.jsx
+++ b/src/id-verification/panels/TakeIdPhotoPanel.jsx
@@ -44,12 +44,12 @@ function TakeIdPhotoPanel(props) {
           </div>
         )}
       </div>
+      {shouldUseCamera && <CameraHelp />}
       <div className="action-row" style={{ visibility: idPhotoFile ? 'unset' : 'hidden' }}>
         <Link to={nextPanelSlug} className="btn btn-primary" data-testid="next-button">
           {props.intl.formatMessage(messages['id.verification.next'])}
         </Link>
       </div>
-      {shouldUseCamera && <CameraHelp />}
     </BasePanel>
   );
 }

--- a/src/id-verification/panels/TakePortraitPhotoPanel.jsx
+++ b/src/id-verification/panels/TakePortraitPhotoPanel.jsx
@@ -44,12 +44,12 @@ function TakePortraitPhotoPanel(props) {
           </div>
         )}
       </div>
+      {shouldUseCamera && <CameraHelp />}
       <div className="action-row" style={{ visibility: facePhotoFile ? 'unset' : 'hidden' }}>
         <Link to={nextPanelSlug} className="btn btn-primary" data-testid="next-button">
           {props.intl.formatMessage(messages['id.verification.next'])}
         </Link>
       </div>
-      {shouldUseCamera && <CameraHelp />}
     </BasePanel>
   );
 }

--- a/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
+++ b/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
@@ -43,12 +43,16 @@ describe('GetNameIdPanel', () => {
         </IntlProvider>
       </Router>
     )));
-    const button = await screen.findByTestId('edit-button');
+    const yesButton = await screen.findByTestId('name-matches-yes');
+    const noButton = await screen.findByTestId('name-matches-no');
     const input = await screen.findByTestId('name-input');
-    expect(input).toHaveProperty('disabled', true);
-    fireEvent.click(button);
-    expect(input).toHaveProperty('disabled', false);
+    expect(input).toHaveProperty('readOnly', true);
+    fireEvent.click(noButton);
+    expect(input).toHaveProperty('readOnly', false);
     fireEvent.change(input, { target: { value: 'test change' } });
+    expect(contextValue.setIdPhotoName).toHaveBeenCalled();
+    fireEvent.click(yesButton);
+    expect(input).toHaveProperty('readOnly', true);
     expect(contextValue.setIdPhotoName).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
[MST-353](https://openedx.atlassian.net/browse/MST-353)

@edx/masters-devs-cosmonauts 

Changes addressed with this PR:

### Review Requirements Panel

- Aria-levels added to headings

### Request Camera Access Panel

- Title changes based on state
---
![Screen Shot 2020-08-10 at 1 30 00 PM](https://user-images.githubusercontent.com/10442143/89813949-70ffe680-db10-11ea-8019-ba0e10d8161c.png)
---
![Screen Shot 2020-08-10 at 1 30 15 PM](https://user-images.githubusercontent.com/10442143/89813956-72c9aa00-db10-11ea-972f-251bf4cc6021.png)
---
![Screen Shot 2020-08-10 at 1 30 34 PM](https://user-images.githubusercontent.com/10442143/89813963-74936d80-db10-11ea-9f35-9a109da0a0e8.png)
---

### Portrait/ID Photo Panels

- 'Next' button comes after FAQ, rather than before
- 'Retake Photo' button changed to Paragon outline variant
- Titles updated to 'Take a Photo of Yourself' and 'Take a Photo of Your ID'
---
![Screen Shot 2020-08-10 at 1 31 13 PM](https://user-images.githubusercontent.com/10442143/89814100-a73d6600-db10-11ea-9a50-7e8a88b36a6c.png)
---

### Account Name Check

- Redesigned to use explicit 'yes' or 'no' radio buttons
- 'Name on ID' changed to 'Account Name'
---
![Screen Shot 2020-08-10 at 1 32 39 PM](https://user-images.githubusercontent.com/10442143/89814319-f4213c80-db10-11ea-819b-97c36ed552a9.png)
---
![Screen Shot 2020-08-10 at 1 40 20 PM](https://user-images.githubusercontent.com/10442143/89814337-fa171d80-db10-11ea-9482-e9625a64a847.png)
---

### Summary Panel

- Buttons updated to Paragon outline variant
- 'Confirm' changed to 'Submit'
---
![Screen Shot 2020-08-10 at 1 41 03 PM](https://user-images.githubusercontent.com/10442143/89814388-0dc28400-db11-11ea-92bd-c4e1d499fe47.png)
---

### Denied Access

- Updated with a relevant message regarding account activation.
- CTA button fixed to include text.
---
![Screen Shot 2020-08-10 at 1 56 55 PM](https://user-images.githubusercontent.com/10442143/89814673-7e69a080-db11-11ea-89d0-6eaabbef0a86.png)
---