### PR TITLE
Fix extra call to LMS when PATCHing demographics

### DIFF
--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -9,6 +9,7 @@ import { handleRequestError, unpackFieldErrors } from './utils';
 import { getThirdPartyAuthProviders } from '../third-party-auth';
 import { getCoachingPreferences, patchCoachingPreferences } from '../coaching/data/service';
 import { getDemographics, patchDemographics } from '../demographics/data/service';
+import { DEMOGRAPHICS_FIELDS } from '../demographics/data/utils';
 
 const SOCIAL_PLATFORMS = [
   { id: 'twitter', key: 'social_link_twitter' },
@@ -211,8 +212,9 @@ export async function patchSettings(username, commitValues, userId) {
   // user/v1/preferences where it does update. This is the one we use.
   const preferenceKeys = ['time_zone'];
   const coachingKeys = ['coaching'];
+  const demographicsKeys = DEMOGRAPHICS_FIELDS;
   const isDemographicsKey = (value, key) => key.includes('demographics');
-  const accountCommitValues = omit(commitValues, preferenceKeys, coachingKeys);
+  const accountCommitValues = omit(commitValues, preferenceKeys, coachingKeys, demographicsKeys);
   const preferenceCommitValues = pick(commitValues, preferenceKeys);
   const coachingCommitValues = pick(commitValues, coachingKeys);
   const demographicsCommitValues = pickBy(commitValues, isDemographicsKey);

--- a/src/account-settings/demographics/data/utils.js
+++ b/src/account-settings/demographics/data/utils.js
@@ -1,5 +1,18 @@
 export const TO = 'to';
 export const FROM = 'from';
+export const DEMOGRAPHICS_FIELDS = [
+  'demographics_gender',
+  'demographics_gender_description',
+  'demographics_income',
+  'demographics_learner_education_level',
+  'demographics_parent_education_level',
+  'demographics_military_history',
+  'demographics_work_status',
+  'demographics_work_status_description',
+  'demographics_current_work_sector',
+  'demographics_future_work_sector',
+  'demographics_user_ethnicity',
+];
 
 // Frontend wants (example):
 //    demographics_user_ethnicity: ["asian", "white", "other"]


### PR DESCRIPTION
We were making an extra call to the LMS when making a PATCH to the
demographics service which we don't need to do.

The keys for demographics fields we not being removed from the
accountSettings object properly, which made them be seen as changes,
which triggered the call to the LMS. I've added a constant
DEMOGRAPHICS_FIELDS that keys out those fields, removing the call.