### PR TITLE
Add tests for new IDV functionality

### DIFF
--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -75,6 +75,7 @@ function SummaryPanel(props) {
               pathname: 'take-portrait-photo',
               state: { fromSummary: true },
             }}
+            data-testid="portrait-retake"
           >
             {props.intl.formatMessage(messages['id.verification.review.portrait.retake'])}
           </Link>
@@ -94,6 +95,7 @@ function SummaryPanel(props) {
               pathname: 'take-id-photo',
               state: { fromSummary: true },
             }}
+            data-testid="id-retake"
           >
             {props.intl.formatMessage(messages['id.verification.review.id.retake'])}
           </Link>

--- a/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
+++ b/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
@@ -46,14 +46,37 @@ describe('GetNameIdPanel', () => {
     const yesButton = await screen.findByTestId('name-matches-yes');
     const noButton = await screen.findByTestId('name-matches-no');
     const input = await screen.findByTestId('name-input');
-    expect(input).toHaveProperty('readOnly', true);
+    const nextButton = await screen.findByTestId('next-button');
+    expect(input).toHaveProperty('readOnly');
     fireEvent.click(noButton);
     expect(input).toHaveProperty('readOnly', false);
+    expect(nextButton.classList.contains('disabled')).toBe(true);
     fireEvent.change(input, { target: { value: 'test change' } });
     expect(contextValue.setIdPhotoName).toHaveBeenCalled();
     fireEvent.click(yesButton);
-    expect(input).toHaveProperty('readOnly', true);
+    expect(input).toHaveProperty('readOnly');
     expect(contextValue.setIdPhotoName).toHaveBeenCalled();
+  });
+
+  it('disables radio buttons + next button and enables input if account name is blank', async () => {
+    contextValue.nameOnAccount = '';
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlGetNameIdPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const yesButton = await screen.findByTestId('name-matches-yes');
+    const noButton = await screen.findByTestId('name-matches-no');
+    const input = await screen.findByTestId('name-input');
+    const nextButton = await screen.findByTestId('next-button');
+    expect(yesButton).toHaveProperty('disabled');
+    expect(noButton).toHaveProperty('disabled');
+    expect(input).toHaveProperty('readOnly', false);
+    expect(nextButton.classList.contains('disabled')).toBe(true);
   });
 
   it('routes to SummaryPanel', async () => {

--- a/src/id-verification/tests/panels/SummaryPanel.test.jsx
+++ b/src/id-verification/tests/panels/SummaryPanel.test.jsx
@@ -32,11 +32,7 @@ describe('SummaryPanel', () => {
     idPhotoName: '',
   };
 
-  afterEach(() => {
-    cleanup();
-  });
-
-  it('submits', async () => {
+  beforeEach(async () => {
     await act(async () => render((
       <Router history={history}>
         <IntlProvider locale="en">
@@ -46,6 +42,27 @@ describe('SummaryPanel', () => {
         </IntlProvider>
       </Router>
     )));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('routes back to TakePortraitPhotoPanel', async () => {
+    const button = await screen.findByTestId('portrait-retake');
+    fireEvent.click(button);
+    expect(history.location.pathname).toEqual('/take-portrait-photo');
+    expect(history.location.state.fromSummary).toEqual(true);
+  });
+
+  it('routes back to TakeIdPhotoPanel', async () => {
+    const button = await screen.findByTestId('id-retake');
+    fireEvent.click(button);
+    expect(history.location.pathname).toEqual('/take-id-photo');
+    expect(history.location.state.fromSummary).toEqual(true);
+  });
+
+  it('submits', async () => {
     const button = await screen.findByTestId('submit-button');
     fireEvent.click(button);
     expect(submitIdVerification).toHaveBeenCalled();

--- a/src/id-verification/tests/panels/TakeIdPhotoPanel.test.jsx
+++ b/src/id-verification/tests/panels/TakeIdPhotoPanel.test.jsx
@@ -62,4 +62,21 @@ describe('TakeIdPhotoPanel', () => {
     fireEvent.click(button);
     expect(history.location.pathname).toEqual('/get-name-id');
   });
+
+  it('routes back to SummaryPanel if that was the source', async () => {
+    contextValue.idPhotoFile = 'test.jpg';
+    history.location.state = { fromSummary: true };
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlTakeIdPhotoPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const button = await screen.findByTestId('next-button');
+    fireEvent.click(button);
+    expect(history.location.pathname).toEqual('/summary');
+  });
 });

--- a/src/id-verification/tests/panels/TakePortraitPhotoPanel.test.jsx
+++ b/src/id-verification/tests/panels/TakePortraitPhotoPanel.test.jsx
@@ -61,4 +61,21 @@ describe('TakePortraitPhotoPanel', () => {
     fireEvent.click(button);
     expect(history.location.pathname).toEqual('/id-context');
   });
+
+  it('routes back to SummaryPanel if that was the source', async () => {
+    contextValue.facePhotoFile = 'test.jpg';
+    history.location.state = { fromSummary: true };
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlTakePortraitPhotoPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const button = await screen.findByTestId('next-button');
+    fireEvent.click(button);
+    expect(history.location.pathname).toEqual('/summary');
+  });
 });


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

Tests added for functionality added with [MST-353](https://openedx.atlassian.net/browse/MST-353). (radio + next buttons are disabled if the learner has a blank account name)

Also covered routing functionality on the summary panel.