### PR TITLE
Limit camera to 720p

### DIFF
--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -19,7 +19,7 @@ class Camera extends React.Component {
 
   componentDidMount() {
     this.cameraPhoto = new CameraPhoto(this.videoRef.current);
-    this.cameraPhoto.startCameraMaxResolution(FACING_MODES.USER);
+    this.cameraPhoto.startCamera(FACING_MODES.USER, { width: 1280 });
   }
 
   takePhoto() {


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

Some users appear to be using hardware that is generating photos up to 10MB+ in size.  LMS can only accept 10MB requests.

This limits the photo to 720p which will produce files ~500kB in size.

I've tested this with multiple camera setups and it appears to correctly limit the devices.