### PR TITLE
Added option for ID image upload

### DIFF
--- a/src/id-verification/CameraHelpWithUpload.jsx
+++ b/src/id-verification/CameraHelpWithUpload.jsx
@@ -1,0 +1,53 @@
+import React, { useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import { Collapsible } from '@edx/paragon';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
+import messages from './IdVerification.messages';
+import ImageFileUpload from './ImageFileUpload';
+import { IdVerificationContext } from './IdVerificationContext';
+import ImagePreview from './ImagePreview';
+
+function CameraHelpWithUpload(props) {
+  const { setIdPhotoFile, idPhotoFile, userId } = useContext(IdVerificationContext);
+  const [hasUploadedImage, setHasUploadedImage] = useState(false);
+
+  function setAndTrackIdPhotoFile(image) {
+    sendTrackEvent('edx.id_verification.upload_id', {
+      category: 'id_verification',
+      user_id: userId,
+    });
+    setHasUploadedImage(true);
+    setIdPhotoFile(image);
+  }
+
+  return (
+    <div>
+      <Collapsible
+        styling="card"
+        title={props.intl.formatMessage(messages['id.verification.id.photo.unclear.question'])}
+        data-testid="collapsible"
+        className="mb-4 shadow"
+        defaultOpen={props.isOpen}
+      >
+        {idPhotoFile && hasUploadedImage && <ImagePreview src={idPhotoFile} alt={props.intl.formatMessage(messages['id.verification.id.photo.preview.alt'])} />}
+        <p>
+          {props.intl.formatMessage(messages['id.verification.id.photo.instructions.upload'])}
+        </p>
+        <ImageFileUpload onFileChange={setAndTrackIdPhotoFile} />
+      </Collapsible>
+    </div>
+  );
+}
+
+CameraHelpWithUpload.propTypes = {
+  intl: intlShape.isRequired,
+  isOpen: PropTypes.bool,
+};
+
+CameraHelpWithUpload.defaultProps = {
+  isOpen: false,
+};
+
+export default injectIntl(CameraHelpWithUpload);

--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -341,6 +341,11 @@ const messages = defineMessages({
     defaultMessage: 'If you require assistance with taking a photo for submission, contact edX support for additional suggestions.',
     description: 'Confirming what to do if the user has difficult holding their head relative to the camera.',
   },
+  'id.verification.id.photo.unclear.question': {
+    id: 'id.verification.id.photo.unclear.question',
+    defaultMessage: 'Is your ID image not clear or too blurry?',
+    description: 'Question on what to do if the user\'s ID image is unclear',
+  },
   'id.verification.id.tips.title': {
     id: 'id.verification.id.tips.title',
     defaultMessage: 'Helpful ID Tips',

--- a/src/id-verification/ImageFileUpload.jsx
+++ b/src/id-verification/ImageFileUpload.jsx
@@ -17,6 +17,7 @@ export default function ImageFileUpload({ onFileChange }) {
     <input
       type="file"
       accept="image/*"
+      data-testid="fileUpload"
       onChange={handleChange}
     />
   );

--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -11,6 +11,7 @@ import { IdVerificationContext } from '../IdVerificationContext';
 import ImagePreview from '../ImagePreview';
 
 import messages from '../IdVerification.messages';
+import CameraHelpWithUpload from '../CameraHelpWithUpload';
 
 function SummaryPanel(props) {
   const panelSlug = 'summary';
@@ -101,6 +102,7 @@ function SummaryPanel(props) {
           </Link>
         </div>
       </div>
+      <CameraHelpWithUpload />
       <div className="form-group">
         <label htmlFor="name-to-be-used">
           {props.intl.formatMessage(messages['id.verification.account.name.label'])}

--- a/src/id-verification/panels/TakeIdPhotoPanel.jsx
+++ b/src/id-verification/panels/TakeIdPhotoPanel.jsx
@@ -4,47 +4,29 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import { useNextPanelSlug } from '../routing-utilities';
 import BasePanel from './BasePanel';
-import ImageFileUpload from '../ImageFileUpload';
-import ImagePreview from '../ImagePreview';
 import Camera from '../Camera';
-import CameraHelp from '../CameraHelp';
 import { IdVerificationContext } from '../IdVerificationContext';
 
 import messages from '../IdVerification.messages';
+import CameraHelp from '../CameraHelp';
 
 function TakeIdPhotoPanel(props) {
   const panelSlug = 'take-id-photo';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
   const { setIdPhotoFile, idPhotoFile } = useContext(IdVerificationContext);
-  const shouldUseCamera = true;
-  // to reenable upload component:
-  // const shouldUseCamera = mediaAccess === MEDIA_ACCESS.GRANTED;
 
   return (
     <BasePanel
       name={panelSlug}
-      title={shouldUseCamera ? props.intl.formatMessage(messages['id.verification.id.photo.title.camera']) : props.intl.formatMessage(messages['id.verification.id.photo.title.upload'])}
+      title={props.intl.formatMessage(messages['id.verification.id.photo.title.camera'])}
     >
       <div>
-        {idPhotoFile && !shouldUseCamera && <ImagePreview src={idPhotoFile} alt={props.intl.formatMessage(messages['id.verification.id.photo.preview.alt'])} />}
-
-        {shouldUseCamera ? (
-          <div>
-            <p>
-              {props.intl.formatMessage(messages['id.verification.id.photo.instructions.camera'])}
-            </p>
-            <Camera onImageCapture={setIdPhotoFile} />
-          </div>
-        ) : (
-          <div>
-            <p>
-              {props.intl.formatMessage(messages['id.verification.id.photo.instructions.upload'])}
-            </p>
-            <ImageFileUpload onFileChange={setIdPhotoFile} />
-          </div>
-        )}
+        <p>
+          {props.intl.formatMessage(messages['id.verification.id.photo.instructions.camera'])}
+        </p>
+        <Camera onImageCapture={setIdPhotoFile} />
       </div>
-      {shouldUseCamera && <CameraHelp />}
+      <CameraHelp />
       <div className="action-row" style={{ visibility: idPhotoFile ? 'unset' : 'hidden' }}>
         <Link to={nextPanelSlug} className="btn btn-primary" data-testid="next-button">
           {props.intl.formatMessage(messages['id.verification.next'])}

--- a/src/id-verification/tests/panels/SummaryPanel.test.jsx
+++ b/src/id-verification/tests/panels/SummaryPanel.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import { render, cleanup, act, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { submitIdVerification } from '../../data/service';
@@ -60,6 +61,13 @@ describe('SummaryPanel', () => {
     fireEvent.click(button);
     expect(history.location.pathname).toEqual('/take-id-photo');
     expect(history.location.state.fromSummary).toEqual(true);
+  });
+
+  it('allows user to upload ID photo', async () => {
+    const collapsible = await screen.getAllByRole('button', { 'aria-expanded': false })[0];
+    fireEvent.click(collapsible);
+    const uploadButton = await screen.getByTestId('fileUpload');
+    expect(uploadButton).toBeVisible();
   });
 
   it('submits', async () => {


### PR DESCRIPTION
## [MST-360](https://openedx.atlassian.net/browse/MST-360)

These changes allow learners to upload a photo of their ID rather than taking a photo with their device's camera. This option to upload is contained by a collapsible component on the summary page.

This is what a user will see on the ID image capture page (no changes):
![Screen Shot 2020-08-24 at 3 19 53 PM](https://user-images.githubusercontent.com/46360176/91087665-d11d7f00-e61e-11ea-97b9-03420da40bd4.png)

This is what a user will see once they reach the summary page:
![Screen Shot 2020-08-24 at 3 20 24 PM](https://user-images.githubusercontent.com/46360176/91087703-dc70aa80-e61e-11ea-8e7a-ede66651058d.png)

When they open the collapsible component:
![Screen Shot 2020-08-24 at 3 29 15 PM](https://user-images.githubusercontent.com/46360176/91087734-ec888a00-e61e-11ea-9ac0-aa8657201c2b.png)

When they upload an image:
![Screen Shot 2020-08-24 at 3 29 25 PM](https://user-images.githubusercontent.com/46360176/91087759-f4e0c500-e61e-11ea-9777-f4845692db49.png)

