### PR TITLE
Added logic for adjusting image resolution

### DIFF
--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -129,14 +129,36 @@ class Camera extends React.Component {
     if (this.state.dataUri) {
       return this.reset();
     }
+
     const config = {
-      sizeFactor: 1,
+      sizeFactor: this.getSizeFactor(),
     };
 
     this.playShutterClick();
     const dataUri = this.cameraPhoto.getDataUri(config);
     this.setState({ dataUri });
     this.props.onImageCapture(dataUri);
+  }
+
+  getSizeFactor() {
+    let sizeFactor = 1;
+    const settings = this.cameraPhoto.getCameraSettings();
+    if (settings) {
+      const videoWidth = settings.width;
+      const videoHeight = settings.height;
+      // need to multiply by 3 because each pixel contains 3 bytes
+      const currentSize = videoWidth * videoHeight * 3;
+      // chose a limit of 9,999,999 (bytes) so that result will
+      // always be less than 10MB
+      const ratio = 9999999 / currentSize;
+
+      // if the current resolution creates an image larger than 10 MB, adjust sizeFactor (resolution)
+      // to ensure that image will have a file size of less than 10 MB.
+      if (ratio < 1) {
+        sizeFactor = ratio;
+      }
+    }
+    return sizeFactor;
   }
 
   playShutterClick() {


### PR DESCRIPTION
## For [CR-2544](https://openedx.atlassian.net/browse/CR-2544)

@edx/masters-devs-cosmonauts 

There are a few learners that are still encountering file size errors when attempting to submit their ID verification. My understanding is that when access to their camera is requested with an ideal resolution and facing mode, the request for that resolution or facing mode is rejected and it falls back to the default resolution and facing mode.

Because of this, additional logic should be added to ensure that if the camera resolution will result in an image with too high of a resolution, there is additional processing done in order to decrease the resolution and therefore decrease the file size. 