### PR TITLE
add playsInline attribute to video element to ensure it does not pop out into full screen video on iOS Safari

### DIFF
--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -58,6 +58,7 @@ class Camera extends React.Component {
             autoPlay={true}
             className='camera-video'
             style={{ display: this.state.dataUri ? 'none' : 'block' }}
+            playsInline
           />
           <img
             alt='imgCamera'


### PR DESCRIPTION
This adds the `playsInline` attribute to the video element displayed by the Camera. This prevents the video element from "popping out" into fullscreen mode on iOS Safari. This was tested with iOS 13.1.3.

Old Behavior
![idv-video-old-behavior](https://user-images.githubusercontent.com/11871801/92273443-5de6f900-eeb9-11ea-8003-a0caf2de4509.gif)

Note that the image that is displayed when the video player is closed is the only image that can be taken with the camera, no matter where the camera is pointing.

New Behavior
![idv-video-new-behavior](https://user-images.githubusercontent.com/11871801/92273253-06e12400-eeb9-11ea-9af7-37bbc91de6d6.gif)
