### PR TITLE
use 'environment' facing mode when using the camera in the ID photo c…

### DIFF
--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -25,7 +25,10 @@ class Camera extends React.Component {
 
   componentDidMount() {
     this.cameraPhoto = new CameraPhoto(this.videoRef.current);
-    this.cameraPhoto.startCamera(FACING_MODES.USER, { width: 640, height: 480 });
+    this.cameraPhoto.startCamera(
+      this.props.isPortrait ? FACING_MODES.USER : FACING_MODES.ENVIRONMENT, 
+      { width: 640, height: 480 }
+    );
   }
 
   async componentWillUnmount() {


### PR DESCRIPTION
use 'environment' facing mode when using the camera in the ID photo context; this will open the rear facing camera on mobile

[facingMode documentation](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/facingMode)

Old Experience

![idv-camera-direction-old](https://user-images.githubusercontent.com/11871801/92748007-bce1bd80-f352-11ea-972f-2d35dd12026c.gif)


New Experience

![idv-camera-direction-new](https://user-images.githubusercontent.com/11871801/92748020-c0754480-f352-11ea-87c0-c82aaa8bfe6c.gif)
