### PR TITLE
Move blazeface package to correct version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4880,8 +4880,8 @@
       }
     },
     "@tensorflow-models/blazeface": {
-      "version": "git+https://github.com/alangsto/blazeface.git#ae2ae0f29538ede33c404e2059608df4c1416bba",
-      "from": "git+https://github.com/alangsto/blazeface.git"
+      "version": "0.0.5",
+      "resolved": "git+https://github.com/alangsto/blazeface.git#ae2ae0f29538ede33c404e2059608df4c1416bba"
     },
     "@tensorflow/tfjs-converter": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/free-regular-svg-icons": "5.7.2",
     "@fortawesome/free-solid-svg-icons": "5.8.2",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@tensorflow-models/blazeface": "git+https://github.com/alangsto/blazeface.git",
+    "@tensorflow-models/blazeface": "0.0.5",
     "@tensorflow/tfjs-converter": "1.6.1",
     "@tensorflow/tfjs-core": "1.6.1",
     "babel-polyfill": "6.26.0",

--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -129,6 +129,7 @@ class Camera extends React.Component {
   }
 
   giveFeedback(numFaces, rightEye, isCorrect) {
+    // testing blazeface
     if (this.state.shouldGiveFeedback) {
       const currentFeedback = this.state.feedback;
       let newFeedback = '';


### PR DESCRIPTION
## [MST-409](https://openedx.atlassian.net/browse/MST-409)

Blazeface was previously being installed from a forked repo in order for it to be es5 compatible. There was a recent PR merge in the tfjs/models repo that allows blazeface to now be es5 compatible. 