### PR TITLE
Ensure that first stream is stopped

### DIFF
--- a/src/id-verification/Camera.jsx
+++ b/src/id-verification/Camera.jsx
@@ -28,7 +28,6 @@ class Camera extends React.Component {
 
   componentDidMount() {
     this.cameraPhoto = new CameraPhoto(this.videoRef.current);
-
     this.cameraPhoto.startCamera(
       this.props.isPortrait ? FACING_MODES.USER : FACING_MODES.ENVIRONMENT,
       { width: 640, height: 480 },

--- a/src/id-verification/IdVerificationContext.jsx
+++ b/src/id-verification/IdVerificationContext.jsx
@@ -45,9 +45,9 @@ function IdVerificationContextProvider({ children }) {
         const stream = await navigator.mediaDevices.getUserMedia({ video: true });
         setMediaAccess(MEDIA_ACCESS.GRANTED);
         setMediaStream(stream);
-        // If we would like to stop the stream immediately. I guess we can leave it open
-        // const tracks = stream.getTracks();
-        // tracks.forEach(track => track.stop());
+        // stop the stream, as we are not using it yet
+        const tracks = stream.getTracks();
+        tracks.forEach(track => track.stop());
       } catch (err) {
         setMediaAccess(MEDIA_ACCESS.DENIED);
       }


### PR DESCRIPTION
## [MST-510](https://openedx.atlassian.net/browse/MST-510)

I think that camera access is not being supported on certain devices because the requested constraints change on each of the panels that request the camera (enabling camera access, portrait photo, and ID photo). 

Overall, I think that camera access should be handled better throughout the flow, but I want to test this out first to see if having active streams is causing the problem.