### PR TITLE
Remove use of course key temporarily

### DIFF
--- a/src/id-verification/data/service.js
+++ b/src/id-verification/data/service.js
@@ -64,7 +64,6 @@ export async function submitIdVerification(verificationData) {
     facePhotoFile: 'face_image',
     idPhotoFile: 'photo_id_image',
     idPhotoName: 'full_name',
-    courseRunKey: 'course_key',
   };
   const postData = {};
   // Don't include blank/null/undefined values.

--- a/src/id-verification/panels/SubmittedPanel.jsx
+++ b/src/id-verification/panels/SubmittedPanel.jsx
@@ -10,17 +10,11 @@ import messages from '../IdVerification.messages';
 
 function SubmittedPanel(props) {
   const { userId } = useContext(IdVerificationContext);
-  const [returnUrl, setReturnUrl] = useState('dashboard');
-  const [returnText, setReturnText] = useState('id.verification.return.dashboard');
   const panelSlug = 'submitted';
 
   // If the user accessed IDV through a course,
   // link back to that course rather than the dashboard
   useEffect(() => {
-    if (sessionStorage.getItem('courseRunKey')) {
-      setReturnUrl(`courses/${sessionStorage.getItem('courseRunKey')}`);
-      setReturnText('id.verification.return.course');
-    }
     sendTrackEvent('edx.id_verification.submitted', {
       category: 'id_verification',
       user_id: userId,
@@ -37,10 +31,10 @@ function SubmittedPanel(props) {
       </p>
       <a
         className="btn btn-primary"
-        href={`${getConfig().LMS_BASE_URL}/${returnUrl}`}
+        href={`${getConfig().LMS_BASE_URL}/dashboard`}
         data-testid="return-button"
       >
-        {props.intl.formatMessage(messages[returnText])}
+        {props.intl.formatMessage(messages['id.verification.return.dashboard'])}
       </a>
     </BasePanel>
   );

--- a/src/id-verification/tests/panels/SubmittedPanel.test.jsx
+++ b/src/id-verification/tests/panels/SubmittedPanel.test.jsx
@@ -47,19 +47,4 @@ describe('SubmittedPanel', () => {
     const button = await screen.findByTestId('return-button');
     expect(button).toHaveTextContent(/Return to Your Dashboard/);
   });
-
-  it('links to course with courseRunKey', async () => {
-    Storage.prototype.getItem = jest.fn(() => 'courseRunKey');
-    await act(async () => render((
-      <Router history={history}>
-        <IntlProvider locale="en">
-          <IdVerificationContext.Provider value={contextValue}>
-            <IntlSubmittedPanel {...defaultProps} />
-          </IdVerificationContext.Provider>
-        </IntlProvider>
-      </Router>
-    )));
-    const button = await screen.findByTestId('return-button');
-    expect(button).toHaveTextContent(/Return to Course/);
-  });
 });


### PR DESCRIPTION
The course key is being parsed incorrectly, leading to 400 errors. This is a temporary fix while we investigate the solution.