### PR TITLE
[MST-567] Allow decoding of query string in IDV flow

### DIFF
--- a/src/id-verification/IdVerificationPage.jsx
+++ b/src/id-verification/IdVerificationPage.jsx
@@ -30,8 +30,11 @@ function IdVerificationPage(props) {
   // Course run key is passed as a query string
   useEffect(() => {
     if (search) {
-      const parsed = qs.parse(search, { ignoreQueryPrefix: true });
-      if (parsed.hasOwnProperty('course_id')) {
+      const parsed = qs.parse(search, {
+        ignoreQueryPrefix: true,
+        interpretNumericEntities: true
+      });
+      if (parsed.hasOwnProperty('course_id') && parsed.course_id) {
         sessionStorage.setItem('courseRunKey', parsed.course_id);
       }
     }

--- a/src/id-verification/tests/IdVerificationPage.test.jsx
+++ b/src/id-verification/tests/IdVerificationPage.test.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import configureStore from 'redux-mock-store';
+import { render, act } from '@testing-library/react';
+import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+
+import IdVerificationPage from '../IdVerificationPage';
+import * as selectors from '../data/selectors';
+
+jest.mock('../data/selectors', () => {
+  return jest.fn().mockImplementation(() => ({ idVerificationSelector: () => ({}) }));
+});
+jest.mock('../IdVerificationContext', () => {
+  const IdVerificationContextProvider = jest.fn(({ children }) => children)
+  return { IdVerificationContextProvider };
+});
+jest.mock('../panels/ReviewRequirementsPanel');
+jest.mock('../panels/RequestCameraAccessPanel');
+jest.mock('../panels/PortraitPhotoContextPanel');
+jest.mock('../panels/TakePortraitPhotoPanel');
+jest.mock('../panels/IdContextPanel');
+jest.mock('../panels/GetNameIdPanel');
+jest.mock('../panels/TakeIdPhotoPanel');
+jest.mock('../panels/SummaryPanel');
+jest.mock('../panels/SubmittedPanel');
+
+const IntlIdVerificationPage = injectIntl(IdVerificationPage);
+
+const mockStore = configureStore();
+const history = createMemoryHistory();
+
+describe('IdVerificationPage', () => {
+  selectors.mockClear();
+  jest.spyOn(Storage.prototype, 'setItem')
+  const store = mockStore();
+  const props = {
+    intl: {},
+  };
+
+  it('does not store irrelevant query params', async () => {
+    history.push('/?test=irrelevant')
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <Provider store={store}>
+            <IntlIdVerificationPage {...props} />
+          </Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    expect(sessionStorage.setItem).toHaveBeenCalledTimes(0);
+  })
+  
+  it('does not store empty course_id', async () => {
+    history.push('/?course_id=')
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <Provider store={store}>
+            <IntlIdVerificationPage {...props} />
+          </Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    expect(sessionStorage.setItem).toHaveBeenCalledTimes(0);
+  })
+
+  it('decodes and stores course_id', async () => {
+    history.push('/?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course')
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <Provider store={store}>
+            <IntlIdVerificationPage {...props} />
+          </Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      'courseRunKey',
+      'course-v1:edX+DemoX+Demo_Course'
+    );
+  });
+});


### PR DESCRIPTION
[MST-567](https://openedx.atlassian.net/browse/MST-567)

Related to https://github.com/edx/edx-platform/pull/25845 and https://github.com/edx/ecommerce/pull/3284

This addition decodes the `course_id` query string passed into the IDV flow, allowing special characters like `+`.