### PR TITLE
[MST-567] Re-enable use of course key in IDV flow

### DIFF
--- a/src/id-verification/panels/SubmittedPanel.jsx
+++ b/src/id-verification/panels/SubmittedPanel.jsx
@@ -11,9 +11,18 @@ import messages from '../IdVerification.messages';
 function SubmittedPanel(props) {
   const { userId } = useContext(IdVerificationContext);
   const panelSlug = 'submitted';
+  const [returnPath, setReturnPath] = useState('dashboard');
+  const [returnText, setReturnText] = useState('id.verification.return.dashboard');
 
   // If the user accessed IDV through a course,
   // link back to that course rather than the dashboard
+  useEffect(() => {
+    if (sessionStorage.getItem('courseRunKey')) {
+      setReturnPath(`courses/${sessionStorage.getItem('courseRunKey')}`);
+      setReturnText('id.verification.return.course');
+    }
+  });
+
   useEffect(() => {
     sendTrackEvent('edx.id_verification.submitted', {
       category: 'id_verification',
@@ -31,10 +40,10 @@ function SubmittedPanel(props) {
       </p>
       <a
         className="btn btn-primary"
-        href={`${getConfig().LMS_BASE_URL}/dashboard`}
+        href={`${getConfig().LMS_BASE_URL}/${returnPath}`}
         data-testid="return-button"
       >
-        {props.intl.formatMessage(messages['id.verification.return.dashboard'])}
+        {props.intl.formatMessage(messages[returnText])}
       </a>
     </BasePanel>
   );

--- a/src/id-verification/tests/panels/SubmittedPanel.test.jsx
+++ b/src/id-verification/tests/panels/SubmittedPanel.test.jsx
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom/extend-expect';
 import { render, cleanup, act, screen } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
+import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { IdVerificationContext } from '../../IdVerificationContext';
 import SubmittedPanel from '../../panels/SubmittedPanel';
@@ -26,15 +27,7 @@ describe('SubmittedPanel', () => {
     idPhotoFile: 'test.jpg',
   };
 
-  beforeEach(() => {
-    global.sessionStorage.getItem = jest.fn();
-  });
-
-  afterEach(() => {
-    cleanup();
-  });
-
-  it('links to dashboard without courseRunKey', async () => {
+  const getPanel = async () => {
     await act(async () => render((
       <Router history={history}>
         <IntlProvider locale="en">
@@ -44,7 +37,28 @@ describe('SubmittedPanel', () => {
         </IntlProvider>
       </Router>
     )));
+  };
+
+  beforeEach(() => {
+    global.sessionStorage.getItem = jest.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('links to dashboard without courseRunKey', async () => {
+    await getPanel();
     const button = await screen.findByTestId('return-button');
     expect(button).toHaveTextContent(/Return to Your Dashboard/);
+    expect(button.getAttribute('href')).toEqual(`${getConfig().LMS_BASE_URL}/dashboard`);
+  });
+
+  it('links to course with courseRunKey', async () => {
+    Storage.prototype.getItem = jest.fn(() => 'test');
+    await getPanel();
+    const button = await screen.findByTestId('return-button');
+    expect(button).toHaveTextContent(/Return to Course/);
+    expect(button.getAttribute('href')).toEqual(`${getConfig().LMS_BASE_URL}/courses/test`);
   });
 });


### PR DESCRIPTION
[MST-567](https://openedx.atlassian.net/browse/MST-567)

If the learner accesses the IDV flow through a course, this redirects them back to that course after they are finished with the verification process, rather than the dashboard. This does **not** re-enable the ability to send the course key back while submitting photos, as this is unneeded in the current flow.