### PR TITLE
Remove text references to edX

### DIFF
--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -58,7 +58,7 @@ const messages = defineMessages({
   },
   'account.settings.section.linked.accounts.description': {
     id: 'account.settings.section.linked.accounts.description',
-    defaultMessage: 'You can link your identity accounts to simplify signing in to edX.',
+    defaultMessage: 'You can link your identity accounts to simplify signing in to Zollege.',
     description: 'The linked accounts section heading description.',
   },
   'account.settings.field.username': {
@@ -68,7 +68,7 @@ const messages = defineMessages({
   },
   'account.settings.field.username.help.text': {
     id: 'account.settings.field.username.help.text',
-    defaultMessage: 'The name that identifies you on edX. You cannot change your username.',
+    defaultMessage: 'The name that identifies you on Zollege. You cannot change your username.',
     description: 'Help text for the account settings username field.',
   },
   'account.settings.field.full.name': {
@@ -103,7 +103,7 @@ const messages = defineMessages({
   },
   'account.settings.field.email.help.text': {
     id: 'account.settings.field.email.help.text',
-    defaultMessage: 'You receive messages from edX and course teams at this address.',
+    defaultMessage: 'You receive messages from Zollege and course teams at this address.',
     description: 'Help text for the account settings email field.',
   },
   'account.settings.field.secondary.email': {
@@ -325,7 +325,7 @@ const messages = defineMessages({
   },
   'account.settings.section.social.media.description': {
     id: 'account.settings.section.social.media.description',
-    defaultMessage: 'Optionally, link your personal accounts to the social media icons on your edX profile.',
+    defaultMessage: 'Optionally, link your personal accounts to the social media icons on your Zollege profile.',
     description: 'Section subheader for social media links settings',
   },
   'account.settings.field.social.platform.name.linkedin': {

--- a/src/account-settings/delete-account/messages.js
+++ b/src/account-settings/delete-account/messages.js
@@ -13,12 +13,12 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.text.1': {
     id: 'account.settings.delete.account.text.1',
-    defaultMessage: 'Please note: Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.',
+    defaultMessage: 'Please note: Deletion of your account and personal data is permanent and cannot be undone. Zollege will not be able to recover your account or the data that is deleted.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.2': {
     id: 'account.settings.delete.account.text.2',
-    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the Zollege app, zollege.com, or any other site hosted by Zollege.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.3.link': {
@@ -28,7 +28,7 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.text.warning': {
     id: 'account.settings.delete.account.text.warning',
-    defaultMessage: 'Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on edX.',
+    defaultMessage: 'Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on Zollege.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.change.instead': {
@@ -39,7 +39,7 @@ const messages = defineMessages({
   'account.settings.delete.account.button': {
     id: 'account.settings.delete.account.button',
     defaultMessage: 'Delete My Account',
-    description: 'Button label to permanently delete your edX account',
+    description: 'Button label to permanently delete your Zollege account',
   },
   'account.settings.delete.account.please.activate': {
     id: 'account.settings.delete.account.please.activate',
@@ -58,12 +58,12 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.modal.text.1': {
     id: 'account.settings.delete.account.modal.text.1',
-    defaultMessage: 'You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.',
+    defaultMessage: 'You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. Zollege will not be able to recover your account or the data that is deleted.',
     description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
   },
   'account.settings.delete.account.modal.text.2': {
     id: 'account.settings.delete.account.modal.text.2',
-    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the Zollege app, zollege.com, or any other site hosted by Zollege.',
     description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
   },
   'account.settings.delete.account.modal.enter.password': {


### PR DESCRIPTION
This PR removes text references to edX in account MFE:

Before this change:

Check the Delete my account section and the description of the username, email and social media fields.


![Screenshot_2021-01-19 Account edX(1)](https://user-images.githubusercontent.com/22335041/105105145-dfff4500-5a89-11eb-97fb-83556427a94d.png)


After this change (devstack):
![Screenshot_2021-01-19 Account edX](https://user-images.githubusercontent.com/22335041/105104933-9151ab00-5a89-11eb-92c0-05913c62fbed.png)


## Reviewers
- [ ] @amalbas
- [ ] @mariajgrimaldi
- [ ] @moisesgsalas