### PR TITLE
Updated blazeface to es5 compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7494,8 +7494,9 @@
       }
     },
     "@tensorflow-models/blazeface": {
-      "version": "git+https://github.com/alangsto/blazeface.git#ae2ae0f29538ede33c404e2059608df4c1416bba",
-      "from": "git+https://github.com/alangsto/blazeface.git"
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@tensorflow-models/blazeface/-/blazeface-0.0.6.tgz",
+      "integrity": "sha512-KIoratAtRymLk1G7b1yorwmHa5R4wMOJc8q9g98bhin0AFbt9Q+Iv7c1raHqAAC66h4HZxCrUbj6f60uIGe6aA=="
     },
     "@tensorflow/tfjs-converter": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/free-regular-svg-icons": "5.7.2",
     "@fortawesome/free-solid-svg-icons": "5.8.2",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@tensorflow-models/blazeface": "git+https://github.com/alangsto/blazeface.git",
+    "@tensorflow-models/blazeface": "0.0.6",
     "@tensorflow/tfjs-converter": "1.6.1",
     "@tensorflow/tfjs-core": "1.6.1",
     "babel-polyfill": "6.26.0",


### PR DESCRIPTION
Blazeface version 0.0.5 was not es5 compatible so we created a forked repo for blazeface and updated it to be es5 compatible. Blazeface 0.0.6 is now es5 compatible so we can point back to the npm version. 