### PR TITLE
[MST-704] Make name parameter optional in IDV submission

### DIFF
--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -33,14 +33,16 @@ function SummaryPanel(props) {
   function SubmitButton() {
     async function handleClick() {
       setIsSubmitting(true);
-      let verificationData = {
+      const verificationData = {
         facePhotoFile,
         idPhotoFile,
-        idPhotoName: nameToBeUsed,
         courseRunKey: sessionStorage.getItem('courseRunKey'),
       };
+      if (idPhotoName) {
+        verificationData.idPhotoName = idPhotoName;
+      }
       if (optimizelyExperimentName) {
-        verificationData = { ...verificationData, optimizelyExperimentName };
+        verificationData.optimizelyExperimentName = optimizelyExperimentName;
       }
       const result = await submitIdVerification(verificationData);
       if (result.success) {

--- a/src/id-verification/tests/panels/SummaryPanel.test.jsx
+++ b/src/id-verification/tests/panels/SummaryPanel.test.jsx
@@ -91,6 +91,34 @@ describe('SummaryPanel', () => {
     await waitFor(() => expect(contextValue.stopUserMedia).toHaveBeenCalled());
   });
 
+  it('does not submit a name if name is blank', async () => {
+    contextValue.idPhotoName = '';
+    const verificationData = {
+      facePhotoFile: contextValue.facePhotoFile,
+      idPhotoFile: contextValue.idPhotoFile,
+      optimizelyExperimentName: contextValue.optimizelyExperimentName,
+      courseRunKey: null,
+    };
+    await getPanel();
+    const button = await screen.findByTestId('submit-button');
+    fireEvent.click(button);
+    expect(dataService.submitIdVerification).toHaveBeenCalledWith(verificationData);
+  });
+
+  it('does not submit a name if name is unchanged', async () => {
+    contextValue.idPhotoName = null;
+    const verificationData = {
+      facePhotoFile: contextValue.facePhotoFile,
+      idPhotoFile: contextValue.idPhotoFile,
+      optimizelyExperimentName: contextValue.optimizelyExperimentName,
+      courseRunKey: null,
+    };
+    await getPanel();
+    const button = await screen.findByTestId('submit-button');
+    fireEvent.click(button);
+    expect(dataService.submitIdVerification).toHaveBeenCalledWith(verificationData);
+  });
+
   it('shows error when cannot submit', async () => {
     dataService.submitIdVerification = jest.fn().mockReturnValue({ success: false });
     await getPanel();


### PR DESCRIPTION
[MST-704](https://openedx.atlassian.net/browse/MST-704)

Even though `full_name` is an optional parameter that should only be submitted when the user is updating their account name, it is currently being sent with every IDV submission. This results in errors when the name is somehow blank, or the learner’s account information is controlled by a third party and can’t be updated through our API.

This update ignores the parameter if the value is `''` or `null`.