### PR TITLE
Remove option to upload if user is in experiment

### DIFF
--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -177,7 +177,7 @@ function SummaryPanel(props) {
           </Link>
         </div>
       </div>
-      <CameraHelpWithUpload />
+      {!optimizelyExperimentName && <CameraHelpWithUpload />}
       <div className="form-group">
         <label htmlFor="name-to-be-used" className="font-weight-bold">
           {props.intl.formatMessage(messages['id.verification.account.name.label'])}

--- a/src/id-verification/tests/panels/SummaryPanel.test.jsx
+++ b/src/id-verification/tests/panels/SummaryPanel.test.jsx
@@ -69,11 +69,13 @@ describe('SummaryPanel', () => {
   });
 
   it('allows user to upload ID photo', async () => {
+    contextValue.optimizelyExperimentName = '';
     await getPanel();
     const collapsible = await screen.getAllByRole('button', { 'aria-expanded': false })[0];
     fireEvent.click(collapsible);
     const uploadButton = await screen.getByTestId('fileUpload');
     expect(uploadButton).toBeVisible();
+    contextValue.optimizelyExperimentName = 'test-experiment';
   });
 
   it('displays warning if account is managed by a third party', async () => {
@@ -175,5 +177,12 @@ describe('SummaryPanel', () => {
     expect(error).toHaveTextContent(
       'A valid account name is required. Please update your account name to match the name on your ID.',
     );
+  });
+
+  it('does not show ID upload option if user is in experiment', async () => {
+    await getPanel();
+    const collapsible = await screen.queryByTestId('collapsible');
+    expect(collapsible).not.toBeInTheDocument();
+    contextValue.optimizelyExperimentName = 'test-experiment';
   });
 });


### PR DESCRIPTION
## [MST-654](https://openedx.atlassian.net/browse/MST-654)
@edx/masters-devs-cosmonauts 

If a user is part of an A/B experiment for IDV, they will not be shown the option to upload an ID photo on the summary panel. 

The current experience looks like this: 
![Screen Shot 2021-03-26 at 11 17 00 AM](https://user-images.githubusercontent.com/46360176/112653524-e660c300-8e24-11eb-8b42-4839e4bf784b.png)

The experiment experience will look like this:
![Screen Shot 2021-03-26 at 11 16 23 AM](https://user-images.githubusercontent.com/46360176/112653598-f5e00c00-8e24-11eb-9b88-cf8686e5a51f.png)
