### PR TITLE
Added upload help text to photo context panels

### DIFF
--- a/src/id-verification/CameraHelp.jsx
+++ b/src/id-verification/CameraHelp.jsx
@@ -1,13 +1,29 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Collapsible } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import messages from './IdVerification.messages';
+import IdVerificationContext from './IdVerificationContext';
 
 function CameraHelp(props) {
+  const { optimizelyExperimentName } = useContext(IdVerificationContext);
+
   return (
     <div>
+      { optimizelyExperimentName
+        && (
+        <Collapsible
+          styling="card"
+          title={props.intl.formatMessage(messages['id.verification.camera.help.upload.question'])}
+          className="mb-4 shadow"
+          defaultOpen={props.isOpen}
+        >
+          <p>
+            {props.intl.formatMessage(messages['id.verification.camera.help.upload.answer'])}
+          </p>
+        </Collapsible>
+        )}
       <Collapsible
         styling="card"
         title={props.intl.formatMessage(messages['id.verification.camera.help.sight.question'])}

--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -446,6 +446,16 @@ const messages = defineMessages({
     defaultMessage: 'If you require assistance with taking a photo for submission, contact edX support for additional suggestions.',
     description: 'Confirming what to do if the user has difficult holding their head relative to the camera.',
   },
+  'id.verification.camera.help.upload.question': {
+    id: 'id.verification.camera.help.upload.question',
+    defaultMessage: 'What if I want to upload a photo instead?',
+    description: 'Question on what to do if the user would like to upload a photo instead.',
+  },
+  'id.verification.camera.help.upload.answer': {
+    id: 'id.verification.camera.help.upload.answer',
+    defaultMessage: 'On the next page you will have the option to switch to upload mode. By selecting that option, you will be able to upload a photo instead.',
+    description: 'Confirming what to do if the user would like to upload a photo.',
+  },
   'id.verification.id.photo.unclear.question': {
     id: 'id.verification.id.photo.unclear.question',
     defaultMessage: 'Is your ID image not clear or too blurry?',

--- a/src/id-verification/tests/panels/IdContextPanel.test.jsx
+++ b/src/id-verification/tests/panels/IdContextPanel.test.jsx
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
@@ -23,6 +24,7 @@ describe('IdContextPanel', () => {
   };
 
   const contextValue = {
+    optimizelyExperimentName: '',
     facePhotoFile: 'test.jpg',
   };
 
@@ -43,5 +45,34 @@ describe('IdContextPanel', () => {
     const button = await screen.findByTestId('next-button');
     fireEvent.click(button);
     expect(history.location.pathname).toEqual('/take-id-photo');
+  });
+
+  it('does not show help text for photo upload if not part of experiment', async () => {
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlIdContextPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const title = await screen.queryByText('What if I want to upload a photo instead?');
+    expect(title).not.toBeInTheDocument();
+  });
+
+  it('shows help text for photo upload if part of experiment', async () => {
+    contextValue.optimizelyExperimentName = 'test';
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlIdContextPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const title = await screen.queryByText('What if I want to upload a photo instead?');
+    expect(title).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## [MST-656](https://openedx.atlassian.net/browse/MST-656)

When a user goes through the IDV experiment, they should have additional help text on the photo context panels explaining that they can also upload photos.

This is what each of the photo context panels will look like in the experiment:

![Screen Shot 2021-03-31 at 2 01 10 PM](https://user-images.githubusercontent.com/46360176/113192340-9fac0800-922c-11eb-9fd6-1ccbd308b78e.png)

![Screen Shot 2021-03-31 at 2 01 26 PM](https://user-images.githubusercontent.com/46360176/113192348-a2a6f880-922c-11eb-809b-3fb7bc68b1d5.png)
