### PR TITLE
feat: Allow users in experiment to continue with upload if no camera access

### DIFF
--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -11,6 +11,11 @@ const messages = defineMessages({
     defaultMessage: 'support',
     description: 'Website support.',
   },
+  'id.verification.continue.upload': {
+    id: 'id.verification.continue.upload',
+    defaultMessage: 'Continue with Upload',
+    description: 'Button to continue with upload.',
+  },
   'id.verification.example.card.alt': {
     id: 'id.verification.example.card.alt',
     defaultMessage: 'Example of a valid identification card with a full name and photo.',

--- a/src/id-verification/IdVerificationContextProvider.jsx
+++ b/src/id-verification/IdVerificationContextProvider.jsx
@@ -108,6 +108,7 @@ export default function IdVerificationContextProvider({ children }) {
         tracks.forEach(track => track.stop());
       } catch (err) {
         setMediaAccess(MEDIA_ACCESS.DENIED);
+        setShouldUseCamera(false);
       }
     },
     stopUserMedia: () => {

--- a/src/id-verification/panels/RequestCameraAccessPanel.jsx
+++ b/src/id-verification/panels/RequestCameraAccessPanel.jsx
@@ -18,7 +18,9 @@ function RequestCameraAccessPanel(props) {
   const [returnText, setReturnText] = useState('id.verification.return.dashboard');
   const panelSlug = 'request-camera-access';
   const nextPanelSlug = useNextPanelSlug(panelSlug);
-  const { tryGetUserMedia, mediaAccess, userId } = useContext(IdVerificationContext);
+  const {
+    tryGetUserMedia, mediaAccess, userId, optimizelyExperimentName,
+  } = useContext(IdVerificationContext);
   const browserName = Bowser.parse(window.navigator.userAgent).browser.name;
 
   useEffect(() => {
@@ -59,6 +61,12 @@ function RequestCameraAccessPanel(props) {
     <a className="btn btn-primary" href={`${getConfig().LMS_BASE_URL}/${returnUrl}`}>
       {props.intl.formatMessage(messages[returnText])}
     </a>
+  );
+
+  const nextButtonLink = (
+    <Link to={nextPanelSlug} className="btn btn-primary" data-testid="next-button">
+      {props.intl.formatMessage(messages['id.verification.continue.upload'])}
+    </Link>
   );
 
   return (
@@ -106,7 +114,7 @@ function RequestCameraAccessPanel(props) {
           </p>
           <EnableCameraDirectionsPanel browserName={browserName} intl={props.intl} />
           <div className="action-row">
-            {returnToDashboardLink}
+            {optimizelyExperimentName ? nextButtonLink : returnToDashboardLink}
           </div>
         </div>
       )}
@@ -118,7 +126,7 @@ function RequestCameraAccessPanel(props) {
           </p>
           <UnsupportedCameraDirectionsPanel browserName={browserName} intl={props.intl} />
           <div className="action-row">
-            {returnToDashboardLink}
+            {optimizelyExperimentName ? nextButtonLink : returnToDashboardLink}
           </div>
         </div>
       )}

--- a/src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx
+++ b/src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx
@@ -84,6 +84,27 @@ describe('RequestCameraAccessPanel', () => {
     expect(text).toHaveTextContent(/It looks like we're unable to access your camera./);
   });
 
+  it('renders correctly with media access denied in optimizely experiment', async () => {
+    contextValue.mediaAccess = 'denied';
+    contextValue.optimizelyExperimentName = 'test';
+    Bowser.parse = jest.fn().mockReturnValue({ browser: { name: '' } });
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlRequestCameraAccessPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const text = await screen.findByTestId('camera-access-failure');
+    expect(text).toHaveTextContent(/It looks like we're unable to access your camera./);
+    const nextButton = await screen.findByText('Continue with Upload');
+    fireEvent.click(nextButton);
+    expect(history.location.pathname).toEqual('/take-portrait-photo');
+    contextValue.optimizelyExperimentName = '';
+  });
+
   it('renders correctly with media access unsupported with Chrome browser', async () => {
     contextValue.mediaAccess = 'unsupported';
     Bowser.parse = jest.fn().mockReturnValue({ browser: { name: 'Chrome' } });
@@ -218,5 +239,47 @@ describe('RequestCameraAccessPanel', () => {
     const button = await screen.findByTestId('next-button');
     fireEvent.click(button);
     expect(history.location.pathname).toEqual('/id-context');
+  });
+
+  it('reroutes correctly to portrait context with no media access', async () => {
+    contextValue.mediaAccess = 'denied';
+    contextValue.optimizelyExperimentName = 'test';
+    history.location.state = { fromPortraitCapture: true };
+
+    Bowser.parse = jest.fn().mockReturnValue({ browser: { name: '' } });
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlRequestCameraAccessPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const button = await screen.findByTestId('next-button');
+    fireEvent.click(button);
+    expect(history.location.pathname).toEqual('/take-portrait-photo');
+    contextValue.optimizelyExperimentName = '';
+  });
+
+  it('reroutes correctly to ID context with no media access', async () => {
+    contextValue.mediaAccess = 'denied';
+    contextValue.optimizelyExperimentName = 'test';
+    history.location.state = { fromIdCapture: true };
+
+    Bowser.parse = jest.fn().mockReturnValue({ browser: { name: '' } });
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlRequestCameraAccessPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const button = await screen.findByTestId('next-button');
+    fireEvent.click(button);
+    expect(history.location.pathname).toEqual('/take-id-photo');
+    contextValue.optimizelyExperimentName = '';
   });
 });


### PR DESCRIPTION
## [MST-716](https://openedx.atlassian.net/browse/MST-716)

If users are part of the A/B experiment for photo upload on the IDV flow, they should be allowed to continue with photo upload if they deny camera access or camera access is unsupported. If they have already denied camera access, they will not be allowed to switch between upload and photo capture mode throughout the flow. Instead the user will only be allowed to complete the flow by uploading photos from their device.

If a user is part of the experiment and has denied/unsupported camera access they will see this panel: 

<img width="724" alt="Screen Shot 2021-04-05 at 1 38 19 PM" src="https://user-images.githubusercontent.com/46360176/113605928-53d6d580-9615-11eb-8567-1197ae42e2b0.png">

If they continue with upload, they will see this panel (that does not give them access to switch to photo capture mode):
<img width="733" alt="Screen Shot 2021-04-05 at 1 38 29 PM" src="https://user-images.githubusercontent.com/46360176/113605977-62bd8800-9615-11eb-859a-ef644aa85833.png">
