### PR TITLE
fix: Resolving i18n violations, hard-coded edx.org-specific strings

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -44,8 +44,8 @@ class AccountSettingsPage extends React.Component {
 
     // If there is a "duplicate_provider" query parameter, that's the backend's
     // way of telling us that the provider account the user tried to link is already linked
-    // to another Open edX account. We use this to display a message to that effect, and remove the
-    // parameter from the URL.
+    // to another user account on the platform. We use this to display a message to that effect,
+    // and remove the parameter from the URL.
     const duplicateTpaProvider = getQueryParameters().duplicate_provider;
     if (duplicateTpaProvider !== undefined) {
       history.replace(history.location.pathname);
@@ -164,10 +164,11 @@ class AccountSettingsPage extends React.Component {
         <Alert className="alert alert-danger" role="alert">
           <FormattedMessage
             id="account.settings.message.duplicate.tpa.provider"
-            defaultMessage="The {provider} account you selected is already linked to another edX account."
-            description="alert message informing the user that the third-party account they attempted to link is already linked to another edX account"
+            defaultMessage="The {provider} account you selected is already linked to another {siteName} account."
+            description="alert message informing the user that the third-party account they attempted to link is already linked to another account"
             values={{
               provider: <b>{this.state.duplicateTpaProvider}</b>,
+              siteName: getConfig().SITE_NAME,
             }}
           />
         </Alert>
@@ -282,7 +283,10 @@ class AccountSettingsPage extends React.Component {
             type="text"
             value={this.props.formValues.username}
             label={this.props.intl.formatMessage(messages['account.settings.field.username'])}
-            helpText={this.props.intl.formatMessage(messages['account.settings.field.username.help.text'])}
+            helpText={this.props.intl.formatMessage(
+              messages['account.settings.field.username.help.text'],
+              { siteName: getConfig().SITE_NAME },
+            )}
             isEditable={false}
             {...editableFieldProps}
           />
@@ -310,7 +314,10 @@ class AccountSettingsPage extends React.Component {
             }
             value={this.props.formValues.email}
             confirmationMessageDefinition={messages['account.settings.field.email.confirmation']}
-            helpText={this.props.intl.formatMessage(messages['account.settings.field.email.help.text'])}
+            helpText={this.props.intl.formatMessage(
+              messages['account.settings.field.email.help.text'],
+              { siteName: getConfig().SITE_NAME },
+            )}
             isEditable={this.isEditable('email')}
             {...editableFieldProps}
           />
@@ -405,7 +412,12 @@ class AccountSettingsPage extends React.Component {
           <h2 className="section-heading">
             {this.props.intl.formatMessage(messages['account.settings.section.social.media'])}
           </h2>
-          <p>{this.props.intl.formatMessage(messages['account.settings.section.social.media.description'])}</p>
+          <p>
+            {this.props.intl.formatMessage(
+              messages['account.settings.section.social.media.description'],
+              { siteName: getConfig().SITE_NAME },
+            )}
+          </p>
 
           <EditableField
             name="social_link_linkedin"
@@ -466,7 +478,12 @@ class AccountSettingsPage extends React.Component {
 
         <div className="account-section" id="linked-accounts" ref={this.navLinkRefs['#linked-accounts']}>
           <h2 className="section-heading">{this.props.intl.formatMessage(messages['account.settings.section.linked.accounts'])}</h2>
-          <p>{this.props.intl.formatMessage(messages['account.settings.section.linked.accounts.description'])}</p>
+          <p>
+            {this.props.intl.formatMessage(
+              messages['account.settings.section.linked.accounts.description'],
+              { siteName: getConfig().SITE_NAME },
+            )}
+          </p>
           <ThirdPartyAuth />
         </div>
 

--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -63,7 +63,7 @@ const messages = defineMessages({
   },
   'account.settings.section.linked.accounts.description': {
     id: 'account.settings.section.linked.accounts.description',
-    defaultMessage: 'You can link your identity accounts to simplify signing in to edX.',
+    defaultMessage: 'You can link your identity accounts to simplify signing in to {siteName}.',
     description: 'The linked accounts section heading description.',
   },
   'account.settings.field.username': {
@@ -73,7 +73,7 @@ const messages = defineMessages({
   },
   'account.settings.field.username.help.text': {
     id: 'account.settings.field.username.help.text',
-    defaultMessage: 'The name that identifies you on edX. You cannot change your username.',
+    defaultMessage: 'The name that identifies you on {siteName}. You cannot change your username.',
     description: 'Help text for the account settings username field.',
   },
   'account.settings.field.full.name': {
@@ -108,7 +108,7 @@ const messages = defineMessages({
   },
   'account.settings.field.email.help.text': {
     id: 'account.settings.field.email.help.text',
-    defaultMessage: 'You receive messages from edX and course teams at this address.',
+    defaultMessage: 'You receive messages from {siteName} and course teams at this address.',
     description: 'Help text for the account settings email field.',
   },
   'account.settings.field.secondary.email': {
@@ -331,7 +331,7 @@ const messages = defineMessages({
   },
   'account.settings.section.social.media.description': {
     id: 'account.settings.section.social.media.description',
-    defaultMessage: 'Optionally, link your personal accounts to the social media icons on your edX profile.',
+    defaultMessage: 'Optionally, link your personal accounts to the social media icons on your {siteName} profile.',
     description: 'Section subheader for social media links settings',
   },
   'account.settings.field.social.platform.name.linkedin': {

--- a/src/account-settings/delete-account/BeforeProceedingBanner.jsx
+++ b/src/account-settings/delete-account/BeforeProceedingBanner.jsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Hyperlink } from '@edx/paragon';
 
 // Messages
+import { getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 
 // Components
@@ -22,13 +23,14 @@ const BeforeProceedingBanner = (props) => {
       <FormattedMessage
         id="account.settings.delete.account.before.proceeding"
         defaultMessage="Before proceeding, please {actionLink}."
-        description="Error that appears if you are trying to delete your edX account, but something about your account needs attention first.  The actionLink will be instructions, such as 'unlink your Facebook account'."
+        description="Error that appears if you are trying to delete your {siteName} account, but something about your account needs attention first.  The actionLink will be instructions, such as 'unlink your Facebook account'."
         values={{
           actionLink: (
             <Hyperlink destination={supportArticleUrl}>
               {intl.formatMessage(messages[instructionMessageId])}
             </Hyperlink>
           ),
+          siteName: getConfig().SITE_NAME,
         }}
       />
     </Alert>

--- a/src/account-settings/delete-account/BeforeProceedingBanner.jsx
+++ b/src/account-settings/delete-account/BeforeProceedingBanner.jsx
@@ -23,7 +23,7 @@ const BeforeProceedingBanner = (props) => {
       <FormattedMessage
         id="account.settings.delete.account.before.proceeding"
         defaultMessage="Before proceeding, please {actionLink}."
-        description="Error that appears if you are trying to delete your {siteName} account, but something about your account needs attention first.  The actionLink will be instructions, such as 'unlink your Facebook account'."
+        description="Error that appears if you are trying to delete your account, but something about your account needs attention first.  The actionLink will be instructions, such as 'unlink your Facebook account'."
         values={{
           actionLink: (
             <Hyperlink destination={supportArticleUrl}>

--- a/src/account-settings/delete-account/ConfirmationModal.jsx
+++ b/src/account-settings/delete-account/ConfirmationModal.jsx
@@ -8,6 +8,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { faExclamationCircle, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 import Alert from '../Alert';
 import PrintingInstructions from './PrintingInstructions';
@@ -65,6 +66,13 @@ export class ConfirmationModal extends Component {
     const open = ['confirming', 'pending', 'failed'].includes(status);
     const passwordFieldId = 'passwordFieldId';
     const invalidMessage = messages[this.getShortErrorMessageId(errorType)];
+
+    // TODO: We lack a good way of providing custom language for a particular site.  This is a hack
+    // to allow edx.org to fulfill its business requirements.
+    const deleteAccountModalText2MessageKey = getConfig().SITE_NAME === 'edX'
+      ? 'account.settings.delete.account.modal.text.2.edX'
+      : 'account.settings.delete.account.modal.text.2';
+
     return (
       <Modal
         open={open}
@@ -77,9 +85,17 @@ export class ConfirmationModal extends Component {
               icon={<FontAwesomeIcon className="mr-2" icon={faExclamationTriangle} />}
             >
               <h6>
-                {intl.formatMessage(messages['account.settings.delete.account.modal.text.1'])}
+                {intl.formatMessage(
+                  messages['account.settings.delete.account.modal.text.1'],
+                  { siteName: getConfig().SITE_NAME },
+                )}
               </h6>
-              <p>{intl.formatMessage(messages['account.settings.delete.account.modal.text.2'])}</p>
+              <p>
+                {intl.formatMessage(
+                  messages[deleteAccountModalText2MessageKey],
+                  { siteName: getConfig().SITE_NAME },
+                )}
+              </p>
               <p>
                 <PrintingInstructions />
               </p>

--- a/src/account-settings/delete-account/DeleteAccount.jsx
+++ b/src/account-settings/delete-account/DeleteAccount.jsx
@@ -60,19 +60,36 @@ export class DeleteAccount extends React.Component {
     } = this.props;
     const canDelete = isVerifiedAccount && !hasLinkedTPA;
 
+    // TODO: We lack a good way of providing custom language for a particular site.  This is a hack
+    // to allow edx.org to fulfill its business requirements.
+    const deleteAccountText2MessageKey = getConfig().SITE_NAME === 'edX'
+      ? 'account.settings.delete.account.text.2.edX'
+      : 'account.settings.delete.account.text.2';
+
     return (
       <div>
         <h2 className="section-heading">
           {intl.formatMessage(messages['account.settings.delete.account.header'])}
         </h2>
         <p>{intl.formatMessage(messages['account.settings.delete.account.subheader'])}</p>
-        <p>{intl.formatMessage(messages['account.settings.delete.account.text.1'])}</p>
-        <p>{intl.formatMessage(messages['account.settings.delete.account.text.2'])}</p>
+        <p>
+          {intl.formatMessage(
+            messages['account.settings.delete.account.text.1'],
+            { siteName: getConfig().SITE_NAME },
+          )}
+        </p>
+        <p>
+          {intl.formatMessage(
+            messages[deleteAccountText2MessageKey],
+            { siteName: getConfig().SITE_NAME },
+          )}
+        </p>
         <p>
           <PrintingInstructions />
         </p>
         <p className="text-danger h6">
-          {intl.formatMessage(messages['account.settings.delete.account.text.warning'])}
+          {intl.formatMessage(messages['account.settings.delete.account.text.warning'],
+            { siteName: getConfig().SITE_NAME })}
         </p>
         <p>
           <Hyperlink destination="https://support.edx.org/hc/en-us/sections/115004139268-Manage-Your-Account-Settings">

--- a/src/account-settings/delete-account/PrintingInstructions.jsx
+++ b/src/account-settings/delete-account/PrintingInstructions.jsx
@@ -24,7 +24,7 @@ const PrintingInstructions = (props) => {
       <FormattedMessage
         id="account.settings.delete.account.text.3.edX"
         defaultMessage="You may also lose access to verified certificates and other program credentials like MicroMasters certificates. You can make a copy of these for your records before proceeding with deletion. {actionLink}."
-        description="A message in the user account deletion area warning users that deleting their account will prevent them from accessing their certificates."
+        description="A message in the user account deletion area warning users that deleting their account will prevent them from accessing their certificates. 'actionLink' is a HTML link with a full sentence that describes how to print a certificate."
         values={{ actionLink }}
       />
     );

--- a/src/account-settings/delete-account/PrintingInstructions.jsx
+++ b/src/account-settings/delete-account/PrintingInstructions.jsx
@@ -2,22 +2,39 @@ import React from 'react';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Hyperlink } from '@edx/paragon';
 
+import { getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 
 const PrintingInstructions = (props) => {
   const actionLink = (
     <Hyperlink
-      destination="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
+      // TODO: What would a generic version of this link look like?  Should
+      // CERTIFICATE_SHARING_HELP_URL really be a configuration variable?  In the meantime,
+      // We've removed the link from the default message.
+      destination="https://support.edx.org/hc/en-us/sections/115004173027-Receive-and-Share-edX-Certificates"
     >
       {props.intl.formatMessage(messages['account.settings.delete.account.text.3.link'])}
     </Hyperlink>
   );
 
+  // TODO: We lack a good way of providing custom language for a particular site.  This is a hack
+  // to allow edx.org to mention MicroMasters certificates to fulfill its business requirements.
+  if (getConfig().SITE_NAME === 'edX') {
+    return (
+      <FormattedMessage
+        id="account.settings.delete.account.text.3.edX"
+        defaultMessage="You may also lose access to verified certificates and other program credentials like MicroMasters certificates. You can make a copy of these for your records before proceeding with deletion. {actionLink}."
+        description="A message in the user account deletion area warning users that deleting their account will prevent them from accessing their certificates."
+        values={{ actionLink }}
+      />
+    );
+  }
+
   return (
     <FormattedMessage
       id="account.settings.delete.account.text.3"
-      defaultMessage="You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, {actionLink}."
-      description="A message in the user account deletion area"
+      defaultMessage="You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion."
+      description="A message in the user account deletion area warning users that deleting their account will prevent them from accessing their certificates."
       values={{ actionLink }}
     />
   );

--- a/src/account-settings/delete-account/__snapshots__/ConfirmationModal.test.jsx.snap
+++ b/src/account-settings/delete-account/__snapshots__/ConfirmationModal.test.jsx.snap
@@ -95,22 +95,14 @@ Array [
                 </div>
                 <div>
                   <h6>
-                    You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.
+                    You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. localhost will not be able to recover your account or the data that is deleted.
                   </h6>
                   <p>
-                    If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer's or university's system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.
+                    If you proceed, you will be unable to use this account to take courses on localhost.
                   </p>
                   <p>
                     <span>
-                      You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, 
-                      <a
-                        href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
-                        onClick={[Function]}
-                        target="_self"
-                      >
-                        follow the instructions for printing or downloading a certificate
-                      </a>
-                      .
+                      You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.
                     </span>
                   </p>
                 </div>
@@ -314,22 +306,14 @@ Array [
                 </div>
                 <div>
                   <h6>
-                    You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.
+                    You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. localhost will not be able to recover your account or the data that is deleted.
                   </h6>
                   <p>
-                    If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer's or university's system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.
+                    If you proceed, you will be unable to use this account to take courses on localhost.
                   </p>
                   <p>
                     <span>
-                      You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, 
-                      <a
-                        href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
-                        onClick={[Function]}
-                        target="_self"
-                      >
-                        follow the instructions for printing or downloading a certificate
-                      </a>
-                      .
+                      You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.
                     </span>
                   </p>
                 </div>
@@ -500,22 +484,14 @@ Array [
                 </div>
                 <div>
                   <h6>
-                    You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.
+                    You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. localhost will not be able to recover your account or the data that is deleted.
                   </h6>
                   <p>
-                    If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer's or university's system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.
+                    If you proceed, you will be unable to use this account to take courses on localhost.
                   </p>
                   <p>
                     <span>
-                      You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, 
-                      <a
-                        href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
-                        onClick={[Function]}
-                        target="_self"
-                      >
-                        follow the instructions for printing or downloading a certificate
-                      </a>
-                      .
+                      You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.
                     </span>
                   </p>
                 </div>

--- a/src/account-settings/delete-account/__snapshots__/DeleteAccount.test.jsx.snap
+++ b/src/account-settings/delete-account/__snapshots__/DeleteAccount.test.jsx.snap
@@ -11,28 +11,20 @@ exports[`DeleteAccount should match default section snapshot 1`] = `
     We're sorry to see you go!
   </p>
   <p>
-    Please note: Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.
+    Please note: Deletion of your account and personal data is permanent and cannot be undone. localhost will not be able to recover your account or the data that is deleted.
   </p>
   <p>
-    Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.
+    Once your account is deleted, you cannot use it to take courses on localhost.
   </p>
   <p>
     <span>
-      You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, 
-      <a
-        href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
-        onClick={[Function]}
-        target="_self"
-      >
-        follow the instructions for printing or downloading a certificate
-      </a>
-      .
+      You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.
     </span>
   </p>
   <p
     className="text-danger h6"
   >
-    Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on edX.
+    Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on localhost.
   </p>
   <p>
     <a
@@ -67,28 +59,20 @@ exports[`DeleteAccount should match unverified account section snapshot 1`] = `
     We're sorry to see you go!
   </p>
   <p>
-    Please note: Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.
+    Please note: Deletion of your account and personal data is permanent and cannot be undone. localhost will not be able to recover your account or the data that is deleted.
   </p>
   <p>
-    Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.
+    Once your account is deleted, you cannot use it to take courses on localhost.
   </p>
   <p>
     <span>
-      You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, 
-      <a
-        href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
-        onClick={[Function]}
-        target="_self"
-      >
-        follow the instructions for printing or downloading a certificate
-      </a>
-      .
+      You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.
     </span>
   </p>
   <p
     className="text-danger h6"
   >
-    Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on edX.
+    Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on localhost.
   </p>
   <p>
     <a
@@ -159,28 +143,20 @@ exports[`DeleteAccount should match unverified account section snapshot 2`] = `
     We're sorry to see you go!
   </p>
   <p>
-    Please note: Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.
+    Please note: Deletion of your account and personal data is permanent and cannot be undone. localhost will not be able to recover your account or the data that is deleted.
   </p>
   <p>
-    Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.
+    Once your account is deleted, you cannot use it to take courses on localhost.
   </p>
   <p>
     <span>
-      You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, 
-      <a
-        href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate"
-        onClick={[Function]}
-        target="_self"
-      >
-        follow the instructions for printing or downloading a certificate
-      </a>
-      .
+      You may also lose access to verified certificates and other program credentials. You can make a copy of these for your records before proceeding with deletion.
     </span>
   </p>
   <p
     className="text-danger h6"
   >
-    Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on edX.
+    Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on localhost.
   </p>
   <p>
     <a

--- a/src/account-settings/delete-account/messages.js
+++ b/src/account-settings/delete-account/messages.js
@@ -13,22 +13,27 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.text.1': {
     id: 'account.settings.delete.account.text.1',
-    defaultMessage: 'Please note: Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.',
+    defaultMessage: 'Please note: Deletion of your account and personal data is permanent and cannot be undone. {siteName} will not be able to recover your account or the data that is deleted.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.2': {
     id: 'account.settings.delete.account.text.2',
-    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on {siteName}.',
+    description: 'A message in the user account deletion area',
+  },
+  'account.settings.delete.account.text.2.edX': {
+    id: 'account.settings.delete.account.text.2.edX',
+    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the {siteName} app, edx.org, or any other site hosted by {siteName}. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.3.link': {
     id: 'account.settings.delete.account.text.3.link',
-    defaultMessage: 'follow the instructions for printing or downloading a certificate',
-    description: 'This text will be a link to a technical support page; it will go in the phrase If you want to make a copy of these for your records, ______ .',
+    defaultMessage: 'Follow these instructions for printing or downloading a certificate',
+    description: 'This text is a link to a technical support page where users can learn how to print or download their certificates.',
   },
   'account.settings.delete.account.text.warning': {
     id: 'account.settings.delete.account.text.warning',
-    defaultMessage: 'Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on edX.',
+    defaultMessage: 'Warning: Account deletion is permanent. Please read the above carefully before proceeding. This is an irreversible action, and you will no longer be able to use the same email on {siteName}.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.change.instead': {
@@ -39,7 +44,7 @@ const messages = defineMessages({
   'account.settings.delete.account.button': {
     id: 'account.settings.delete.account.button',
     defaultMessage: 'Delete My Account',
-    description: 'Button label to permanently delete your edX account',
+    description: 'Button label to permanently delete your platform account',
   },
   'account.settings.delete.account.please.activate': {
     id: 'account.settings.delete.account.please.activate',
@@ -58,12 +63,17 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.modal.text.1': {
     id: 'account.settings.delete.account.modal.text.1',
-    defaultMessage: 'You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. edX will not be able to recover your account or the data that is deleted.',
+    defaultMessage: 'You have selected "Delete My Account". Deletion of your account and personal data is permanent and cannot be undone. {siteName} will not be able to recover your account or the data that is deleted.',
     description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
   },
   'account.settings.delete.account.modal.text.2': {
     id: 'account.settings.delete.account.modal.text.2',
-    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on {siteName}.',
+    description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
+  },
+  'account.settings.delete.account.modal.text.2.edX': {
+    id: 'account.settings.delete.account.modal.text.2.edX',
+    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the {siteName} app, edx.org, or any other site hosted by {siteName}. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
     description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
   },
   'account.settings.delete.account.modal.enter.password': {

--- a/src/account-settings/delete-account/messages.js
+++ b/src/account-settings/delete-account/messages.js
@@ -23,7 +23,7 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.text.2.edX': {
     id: 'account.settings.delete.account.text.2.edX',
-    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the {siteName} app, edx.org, or any other site hosted by {siteName}. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
     description: 'A message in the user account deletion area',
   },
   'account.settings.delete.account.text.3.link': {
@@ -73,7 +73,7 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.modal.text.2.edX': {
     id: 'account.settings.delete.account.modal.text.2.edX',
-    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the {siteName} app, edx.org, or any other site hosted by {siteName}. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
+    defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
     description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
   },
   'account.settings.delete.account.modal.enter.password': {

--- a/src/account-settings/demographics/DemographicsSection.jsx
+++ b/src/account-settings/demographics/DemographicsSection.jsx
@@ -172,7 +172,12 @@ class DemographicsSection extends React.Component {
             target="_blank"
             rel="noopener noreferrer"
           >
-            {this.props.intl.formatMessage(messages['account.settings.section.demographics.why'])}
+            {this.props.intl.formatMessage(
+              messages['account.settings.section.demographics.why'],
+              {
+                siteName: getConfig().SITE_NAME,
+              },
+            )}
           </Hyperlink>
         </p>
         {this.renderDemographicsServiceIssueWarning()}

--- a/src/account-settings/demographics/DemographicsSection.messages.jsx
+++ b/src/account-settings/demographics/DemographicsSection.messages.jsx
@@ -162,7 +162,7 @@ const messages = defineMessages({
   /* Legal copy link text */
   'account.settings.section.demographics.why': {
     id: 'account.settings.section.demographics.why',
-    defaultMessage: 'Why does edX collect this information?',
+    defaultMessage: 'Why does {siteName} collect this information?',
     description: 'Link text for a link to external legal text',
   },
 });

--- a/src/account-settings/demographics/test/__snapshots__/DemographicsSection.test.jsx.snap
+++ b/src/account-settings/demographics/test/__snapshots__/DemographicsSection.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`DemographicsSection should render 1`] = `
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span
@@ -627,7 +627,7 @@ exports[`DemographicsSection should render an Alert if an error occurs 1`] = `
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span
@@ -1251,7 +1251,7 @@ exports[`DemographicsSection should render an Alert when demographicsOptions pro
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span
@@ -1297,7 +1297,7 @@ exports[`DemographicsSection should render ethnicity correctly when multiple opt
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span
@@ -1900,7 +1900,7 @@ exports[`DemographicsSection should render ethnicity text correctly 1`] = `
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span
@@ -2503,7 +2503,7 @@ exports[`DemographicsSection should set user input correctly when user provides 
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span
@@ -3113,7 +3113,7 @@ exports[`DemographicsSection should set user input correctly when user provides 
       rel="noopener noopener noreferrer"
       target="_blank"
     >
-      Why does edX collect this information?
+      Why does localhost collect this information?
       <span>
          
         <span

--- a/src/account-settings/third-party-auth/ThirdPartyAuth.jsx
+++ b/src/account-settings/third-party-auth/ThirdPartyAuth.jsx
@@ -100,7 +100,7 @@ class ThirdPartyAuth extends Component {
       <FormattedMessage
         id="account.settings.sso.no.providers"
         defaultMessage="No accounts can be linked at this time."
-        description="Displayed when no third party accounts are available to link an edX account to"
+        description="Displayed when no third-party accounts are available for the user to link to their account on the platform."
       />
     );
   }

--- a/src/id-verification/CameraHelp.jsx
+++ b/src/id-verification/CameraHelp.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Collapsible } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
+import { getConfig } from '@edx/frontend-platform';
 import messages from './IdVerification.messages';
 import IdVerificationContext from './IdVerificationContext';
 
@@ -41,7 +42,10 @@ function CameraHelp(props) {
         defaultOpen={props.isOpen}
       >
         <p>
-          {props.intl.formatMessage(messages['id.verification.camera.help.difficulty.answer'])}
+          {props.intl.formatMessage(
+            messages['id.verification.camera.help.difficulty.answer'],
+            { siteName: getConfig().SITE_NAME },
+          )}
         </p>
       </Collapsible>
     </div>

--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -58,23 +58,23 @@ const messages = defineMessages({
   },
   'id.verification.privacy.need.photo.question': {
     id: 'id.verification.privacy.need.photo.question',
-    defaultMessage: 'Why does edX need my photo?',
-    description: 'Question about why edX needs a verification photo.',
+    defaultMessage: 'Why does {siteName} need my photo?',
+    description: 'Question about why the platform needs a verification photo.',
   },
   'id.verification.privacy.need.photo.answer': {
     id: 'id.verification.privacy.need.photo.answer',
     defaultMessage: 'We use your verification photos to confirm your identity and ensure the validity of your certificate.',
-    description: 'Answering why edX needs a verification photo.',
+    description: 'Answering why the platform needs a verification photo.',
   },
   'id.verification.privacy.do.with.photo.question': {
     id: 'id.verification.privacy.do.with.photo.question',
-    defaultMessage: 'What does edX do with this photo?',
-    description: 'Question about what edX does with the verification photo.',
+    defaultMessage: 'What does {siteName} do with this photo?',
+    description: 'Question about what the platform does with the verification photo.',
   },
   'id.verification.privacy.do.with.photo.answer': {
     id: 'id.verification.privacy.do.with.photo.answer',
-    defaultMessage: 'We securely encrypt your photo and send it our authorization service for review. Your photo and information are not saved or visible anywhere on edX after the verification process is complete.',
-    description: 'Answering what edX does with the verification photo.',
+    defaultMessage: 'We securely encrypt your photo and send it our authorization service for review. Your photo and information are not saved or visible anywhere on {siteName} after the verification process is complete.',
+    description: 'Answering what the platform does with the verification photo.',
   },
   'id.verification.access.blocked.title': {
     id: 'id.verification.access.blocked.title',
@@ -448,7 +448,7 @@ const messages = defineMessages({
   },
   'id.verification.camera.help.difficulty.answer': {
     id: 'id.verification.camera.help.difficulty.answer',
-    defaultMessage: 'If you require assistance with taking a photo for submission, contact edX support for additional suggestions.',
+    defaultMessage: 'If you require assistance with taking a photo for submission, contact {siteName} support for additional suggestions.',
     description: 'Confirming what to do if the user has difficult holding their head relative to the camera.',
   },
   'id.verification.camera.help.upload.question': {
@@ -643,8 +643,8 @@ const messages = defineMessages({
   },
   'id.verification.review.error': {
     id: 'id.verification.review.error',
-    defaultMessage: 'edX Support Page',
-    description: 'Text linking to the support page.',
+    defaultMessage: '{siteName} Support Page',
+    description: 'Text linking to the platform support page.',
   },
   'id.verification.submitted.title': {
     id: 'id.verification.submitted.title',

--- a/src/id-verification/IdVerificationPage.jsx
+++ b/src/id-verification/IdVerificationPage.jsx
@@ -6,6 +6,7 @@ import {
 import qs from 'qs';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Modal, Button } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform';
 import { idVerificationSelector } from './data/selectors';
 import './getUserMediaShim';
 
@@ -77,10 +78,25 @@ function IdVerificationPage(props) {
           title={props.intl.formatMessage(messages['id.verification.privacy.title'])}
           body={(
             <div>
-              <h6>{props.intl.formatMessage(messages['id.verification.privacy.need.photo.question'])}</h6>
+              <h6>
+                {props.intl.formatMessage(
+                  messages['id.verification.privacy.need.photo.question'],
+                  { siteName: getConfig().SITE_NAME },
+                )}
+              </h6>
               <p>{props.intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}</p>
-              <h6>{props.intl.formatMessage(messages['id.verification.privacy.do.with.photo.question'])}</h6>
-              <p>{props.intl.formatMessage(messages['id.verification.privacy.do.with.photo.answer'])}</p>
+              <h6>
+                {props.intl.formatMessage(
+                  messages['id.verification.privacy.do.with.photo.question'],
+                  { siteName: getConfig().SITE_NAME },
+                )}
+              </h6>
+              <p>
+                {props.intl.formatMessage(
+                  messages['id.verification.privacy.do.with.photo.answer'],
+                  { siteName: getConfig().SITE_NAME },
+                )}
+              </p>
             </div>
           )}
           onClose={() => setIsModalOpen(false)}

--- a/src/id-verification/panels/ReviewRequirementsPanel.jsx
+++ b/src/id-verification/panels/ReviewRequirementsPanel.jsx
@@ -112,16 +112,25 @@ function ReviewRequirementsPanel(props) {
         {props.intl.formatMessage(messages['id.verification.privacy.title'])}
       </h4>
       <h6 aria-level="3">
-        {props.intl.formatMessage(messages['id.verification.privacy.need.photo.question'])}
+        {props.intl.formatMessage(
+          messages['id.verification.privacy.need.photo.question'],
+          { siteName: getConfig().SITE_NAME },
+        )}
       </h6>
       <p>
         {props.intl.formatMessage(messages['id.verification.privacy.need.photo.answer'])}
       </p>
       <h6 aria-level="3">
-        {props.intl.formatMessage(messages['id.verification.privacy.do.with.photo.question'])}
+        {props.intl.formatMessage(
+          messages['id.verification.privacy.do.with.photo.question'],
+          { siteName: getConfig().SITE_NAME },
+        )}
       </h6>
       <p>
-        {props.intl.formatMessage(messages['id.verification.privacy.do.with.photo.answer'])}
+        {props.intl.formatMessage(
+          messages['id.verification.privacy.do.with.photo.answer'],
+          { siteName: getConfig().SITE_NAME },
+        )}
       </p>
 
       <div className="action-row">

--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -128,7 +128,16 @@ function SummaryPanel(props) {
           This might be a temporary issue, so please try again in a few minutes.
           If the problem persists, please go to {support_link} for help.
         `}
-        values={{ support_link: <Alert.Link href="https://support.edx.org/hc/en-us">{props.intl.formatMessage(messages['id.verification.review.error'])}</Alert.Link> }}
+        values={{
+          support_link: (
+            <Alert.Link href="https://support.edx.org/hc/en-us">
+              {props.intl.formatMessage(
+                messages['id.verification.review.error'],
+                { siteName: getConfig().SITE_NAME },
+              )}
+            </Alert.Link>
+          ),
+        }}
       />
     );
   }


### PR DESCRIPTION
This is most easily reviewed commit-by-commit. 

You can read about it in the comments, but it includes a bit of a hack to show alternate messages if the SITE_NAME is set to 'edX'.  This is because we have no way of supplying site-specific strings today, but needed to make the defaults Open edX-friendly.

Later, if we can find a way to include site-specific stuff, we could undo this.  It's all annotated as TODOs.

Will cherry-pick to lilac.master once we get it in.