### PR TITLE
chore: let renovate be more liberal about what it merges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,15 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":automergeLinters",
+    ":automergeTesters",
+    ":automergeMinor",
+    ":noUnscheduledUpdates",
+    ":semanticCommits"
   ],
-  "patch": {
-    "automerge": true
-  },
   "rebaseStalePrs": true,
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["^@edx/paragon"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "stabilityDays": 3
-    }
-  ]
+  "schedule": [
+    "every weekend"
+  ],
+  "timezone": "America/New_York"
 }


### PR DESCRIPTION
This repo was allowing both patch/minor updates of Paragon, but I've opened that up a bit with this PR.  This is based on similar config we've used in other repositories.

It loses the "stability days" that were here, but I don't think we need that for patch/minor updates.