### PR TITLE
build(renovate): be more selective about automerging devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "extends": [
     "config:base",
     "schedule:weekly",
+    ":automergeLinters",
     ":automergeMinor",
+    ":automergeTesters",
     ":enableVulnerabilityAlerts",
     ":rebaseStalePrs",
     ":semanticCommits",
@@ -12,7 +14,12 @@
     {
       "matchDepTypes": [
         "devDependencies",
-        "lockFileMaintenance"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance",
+        "minor",
+        "patch",
+        "pin"
       ],
       "automerge": true
     }


### PR DESCRIPTION
to avoid bumping the major version, besides linters and testers.