### PR TITLE
feat: Update IDV workflow to use the VerifiedName

### DIFF
--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -176,12 +176,12 @@ export async function shouldDisplayDemographicsQuestions() {
   return false;
 }
 
-export async function getVerifiedName(username) {
+export async function getVerifiedName() {
   let data;
   const client = getAuthenticatedHttpClient();
   try {
-    ({ data } = await client
-      .get(`${getConfig().LMS_BASE_URL}/api/edx_name_affirmation/v1/verified_name?username=${username}`));
+    const requestUrl = `${getConfig().LMS_BASE_URL}/api/edx_name_affirmation/v1/verified_name`;
+    ({ data } = await client.get(requestUrl));
   } catch (error) {
     return {};
   }
@@ -215,7 +215,7 @@ export async function getSettings(username, userRoles, userId) {
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && shouldDisplayDemographicsQuestions(),
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && getDemographics(userId),
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && getDemographicsOptions(),
-    getVerifiedName(username),
+    getVerifiedName(),
   ]);
 
   return {

--- a/src/id-verification/IdVerificationContextProvider.jsx
+++ b/src/id-verification/IdVerificationContextProvider.jsx
@@ -2,7 +2,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import { getProfileDataManager } from '../account-settings/data/service';
+import { getProfileDataManager, getVerifiedName } from '../account-settings/data/service';
 import PageLoading from '../account-settings/PageLoading';
 
 import { getExistingIdVerification, getEnrollments } from './data/service';
@@ -76,6 +76,19 @@ export default function IdVerificationContextProvider({ children }) {
     }
   }, [authenticatedUser]);
 
+  const [verifiedName, setVerifiedName] = useState('');
+  useEffect(() => {
+    // Make the API call to retrieve VerifiedName of the learner.
+    // If the learner do not have such attribute from their account, that's OK.
+    // If the learner do have the attribute, the VerifiedName is overriding authenticatedUser.name
+    (async () => {
+      const verifiedNameResponse = await getVerifiedName();
+      if (verifiedNameResponse) {
+        setVerifiedName(verifiedNameResponse.verified_name);
+      }
+    })();
+  }, []);
+
   const [optimizelyExperimentName, setOptimizelyExperimentName] = useState('');
   const [shouldUseCamera, setShouldUseCamera] = useState(false);
 
@@ -95,7 +108,7 @@ export default function IdVerificationContextProvider({ children }) {
     mediaStream,
     mediaAccess,
     userId: authenticatedUser.userId,
-    nameOnAccount: authenticatedUser.name,
+    nameOnAccount: verifiedName || authenticatedUser.name,
     profileDataManager,
     optimizelyExperimentName,
     shouldUseCamera,

--- a/src/id-verification/tests/IdVerificationContextProvider.test.jsx
+++ b/src/id-verification/tests/IdVerificationContextProvider.test.jsx
@@ -5,13 +5,14 @@ import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import { getProfileDataManager } from '../../account-settings/data/service';
+import { getProfileDataManager, getVerifiedName } from '../../account-settings/data/service';
 
 import { getExistingIdVerification, getEnrollments } from '../data/service';
 import IdVerificationContextProvider from '../IdVerificationContextProvider';
 
 jest.mock('../../account-settings/data/service', () => ({
   getProfileDataManager: jest.fn(),
+  getVerifiedName: jest.fn(),
 }));
 
 jest.mock('../data/service', () => ({
@@ -61,5 +62,17 @@ describe('IdVerificationContextProvider', () => {
       context.authenticatedUser.username,
       context.authenticatedUser.roles,
     );
+  });
+
+  it('calls getVerifiedName', async () => {
+    const context = { authenticatedUser: { userId: 3, roles: [] } };
+    await act(async () => render((
+      <AppContext.Provider value={context}>
+        <IntlProvider locale="en">
+          <IdVerificationContextProvider {...defaultProps} />
+        </IntlProvider>
+      </AppContext.Provider>
+    )));
+    expect(getVerifiedName).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
If the Verified Name feature is turned on, and the user do have a VerifiedName, use that name on the Account Name Check page of the IDV flow instead of account profile name