### PR TITLE
fix: Should not display error message when the account name matches the ID name

### DIFF
--- a/src/id-verification/panels/GetNameIdPanel.jsx
+++ b/src/id-verification/panels/GetNameIdPanel.jsx
@@ -146,9 +146,15 @@ function GetNameIdPanel(props) {
             onChange={e => setIdPhotoName(e.target.value)}
             data-testid="name-input"
           />
-          <Form.Control.Feedback id="photo-id-name-feedback" type="invalid">
-            {getErrorMessage()}
-          </Form.Control.Feedback>
+          {(invalidName || profileDataManager) && (
+            <Form.Control.Feedback
+              id="photo-id-name-feedback"
+              data-testid="id-name-feedback-message"
+              type="invalid"
+            >
+              {getErrorMessage()}
+            </Form.Control.Feedback>
+          )}
         </Form.Group>
       </Form>
 

--- a/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
+++ b/src/id-verification/tests/panels/GetNameIdPanel.test.jsx
@@ -54,8 +54,10 @@ describe('GetNameIdPanel', () => {
     const noButton = await screen.findByTestId('name-matches-no');
     const input = await screen.findByTestId('name-input');
     const nextButton = await screen.findByTestId('next-button');
+    const errorMessageQuery = await screen.queryByTestId('id-name-feedback-message');
 
     expect(input).toHaveProperty('readOnly');
+    expect(errorMessageQuery).toBeNull();
 
     fireEvent.click(noButton);
     expect(input).toHaveProperty('readOnly', false);
@@ -63,6 +65,8 @@ describe('GetNameIdPanel', () => {
 
     fireEvent.change(input, { target: { value: 'test change' } });
     expect(contextValue.setIdPhotoName).toHaveBeenCalled();
+    // Ensure the feedback message on name shows when the user says the name does not match ID
+    expect(await screen.queryByTestId('id-name-feedback-message')).toBeTruthy();
 
     fireEvent.click(yesButton);
     expect(input).toHaveProperty('readOnly');
@@ -77,11 +81,13 @@ describe('GetNameIdPanel', () => {
     const noButton = await screen.findByTestId('name-matches-no');
     const input = await screen.findByTestId('name-input');
     const nextButton = await screen.findByTestId('next-button');
+    const errorMessageQuery = await screen.queryByTestId('id-name-feedback-message');
 
     expect(yesButton).toHaveProperty('disabled');
     expect(noButton).toHaveProperty('disabled');
     expect(input).toHaveProperty('readOnly', false);
     expect(nextButton.classList.contains('disabled')).toBe(true);
+    expect(errorMessageQuery).toBeTruthy();
   });
 
   it('blocks the user from changing account name if managed by a third party', async () => {


### PR DESCRIPTION
### Description
MST-990, we should fix the problem where the ID name error message still show up with Account name filled in or Verified name filled in.

### Before the change:
![beforeIdNameErrorFix](https://user-images.githubusercontent.com/16839373/130466934-efc8b071-9460-407d-9ca6-c935f829a404.png)


### After the change:
![afterIDNameErrorFix](https://user-images.githubusercontent.com/16839373/130466897-ea1bd89c-03c4-40e0-8536-48a30df9b67b.png)
