### PR TITLE
feat: if verified name is on, we can redo ID verification

### DIFF
--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -176,6 +176,19 @@ export async function shouldDisplayDemographicsQuestions() {
   return false;
 }
 
+export async function getVerifiedNameEnabled() {
+  let data;
+  const client = getAuthenticatedHttpClient();
+  try {
+    const requestUrl = `${getConfig().LMS_BASE_URL}/api/edx_name_affirmation/v1/verified_name_enabled`;
+    ({ data } = await client.get(requestUrl));
+  } catch (error) {
+    return {};
+  }
+
+  return data;
+}
+
 export async function getVerifiedName() {
   let data;
   const client = getAuthenticatedHttpClient();

--- a/src/id-verification/IdVerificationContextProvider.jsx
+++ b/src/id-verification/IdVerificationContextProvider.jsx
@@ -30,7 +30,7 @@ export default function IdVerificationContextProvider({ children }) {
     hasGetUserMediaSupport ? MEDIA_ACCESS.PENDING : MEDIA_ACCESS.UNSUPPORTED,
   );
 
-  const [verifiedNameEnabled, setVerifiedNameEnabled] = useState('');
+  const [verifiedNameEnabled, setVerifiedNameEnabled] = useState(false);
   useEffect(() => {
     // Make the API call to retrieve VerifiedNameEnabled
     (async () => {

--- a/src/id-verification/tests/IdVerificationContextProvider.test.jsx
+++ b/src/id-verification/tests/IdVerificationContextProvider.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import { getProfileDataManager, getVerifiedName } from '../../account-settings/data/service';
+import { getProfileDataManager, getVerifiedName, getVerifiedNameEnabled } from '../../account-settings/data/service';
 
 import { getExistingIdVerification, getEnrollments } from '../data/service';
 import IdVerificationContextProvider from '../IdVerificationContextProvider';
@@ -13,6 +13,7 @@ import IdVerificationContextProvider from '../IdVerificationContextProvider';
 jest.mock('../../account-settings/data/service', () => ({
   getProfileDataManager: jest.fn(),
   getVerifiedName: jest.fn(),
+  getVerifiedNameEnabled: jest.fn(),
 }));
 
 jest.mock('../data/service', () => ({
@@ -74,5 +75,17 @@ describe('IdVerificationContextProvider', () => {
       </AppContext.Provider>
     )));
     expect(getVerifiedName).toHaveBeenCalled();
+  });
+
+  it('calls getVerifiedNameEnabled', async () => {
+    const context = { authenticatedUser: { userId: 3, roles: [] } };
+    await act(async () => render((
+      <AppContext.Provider value={context}>
+        <IntlProvider locale="en">
+          <IdVerificationContextProvider {...defaultProps} />
+        </IntlProvider>
+      </AppContext.Provider>
+    )));
+    expect(getVerifiedNameEnabled).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The verified_name endpoint provides is_enabled only if a name exists and otherwise 404s, so we have to request the enabled flag separately through the new endpoint to make sure we get it.

Validated on local build with an approved IDV and name affirmation on and off.

MST-1026