### PR TITLE
Fix i18n issues

### DIFF
--- a/src/account-settings/delete-account/BeforeProceedingBanner.jsx
+++ b/src/account-settings/delete-account/BeforeProceedingBanner.jsx
@@ -21,15 +21,10 @@ const BeforeProceedingBanner = (props) => {
       icon={<FontAwesomeIcon className="mr-2" icon={faExclamationTriangle} />}
     >
       <FormattedMessage
-        id="account.settings.delete.account.before.proceeding"
-        defaultMessage="Before proceeding, please {actionLink}."
-        description="Error that appears if you are trying to delete your account, but something about your account needs attention first.  The actionLink will be instructions, such as 'unlink your Facebook account'."
+        defaultMessage=intl.formatMessage(
+          messages[instructionMessageId], {linkStart: <Hyperlink destination={supportArticleURL}>, linkEnd=</Hyperlink>}
+        )
         values={{
-          actionLink: (
-            <Hyperlink destination={supportArticleUrl}>
-              {intl.formatMessage(messages[instructionMessageId])}
-            </Hyperlink>
-          ),
           siteName: getConfig().SITE_NAME,
         }}
       />

--- a/src/account-settings/delete-account/messages.js
+++ b/src/account-settings/delete-account/messages.js
@@ -24,7 +24,7 @@ const messages = defineMessages({
   'account.settings.delete.account.text.2.edX': {
     id: 'account.settings.delete.account.text.2.edX',
     defaultMessage: 'Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
-    description: 'A message in the user account deletion area',
+    description: 'A message in the user account deletion area. This message will NOT be used on Open edX installations. Please do not translate \'MIT Open Learning\', \'Wharton Executive Education\', or \'Harvard Medical School\'',
   },
   'account.settings.delete.account.text.3.link': {
     id: 'account.settings.delete.account.text.3.link',
@@ -74,7 +74,7 @@ const messages = defineMessages({
   'account.settings.delete.account.modal.text.2.edX': {
     id: 'account.settings.delete.account.modal.text.2.edX',
     defaultMessage: 'If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer\'s or university\'s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.',
-    description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account',
+    description: 'Messaging in the dialog asking user to confirm that they want to delete their entire account. This message will NOT be used on Open edX installations. Please do not translate \'MIT Open Learning\', \'Wharton Executive Education\', or \'Harvard Medical School\'',
   },
   'account.settings.delete.account.modal.enter.password': {
     id: 'account.settings.delete.account.modal.enter.password',

--- a/src/account-settings/delete-account/messages.js
+++ b/src/account-settings/delete-account/messages.js
@@ -48,13 +48,13 @@ const messages = defineMessages({
   },
   'account.settings.delete.account.please.activate': {
     id: 'account.settings.delete.account.please.activate',
-    defaultMessage: 'activate your account',
-    description: 'This is the text on a link that goes to the support page.  It is part of this sentence: Before proceeding, please activate your account.',
+    defaultMessage: 'Before proceeding, please {linkStart}activate your account{linkEnd}',
+    description: 'This message links to a support article',
   },
   'account.settings.delete.account.please.unlink': {
     id: 'account.settings.delete.account.please.unlink',
-    defaultMessage: 'unlink all social media accounts',
-    description: 'This is the text on a link that goes to the support page.  It is part of this sentence: Before proceeding, please unlink all social media accounts.',
+    defaultMessage: 'Before proceeding, please {linkStart}unlink all social media accounts{linkEnd}',
+    description: 'This message links to a support article',
   },
   'account.settings.delete.account.modal.header': {
     id: 'account.settings.delete.account.modal.header',


### PR DESCRIPTION
(1) Indicate to translators when strings that reference `edX` are only being used on edx.org. Also add notes about what _shouldn't_ be translated.

(2) Fix an issue where strings were split into two messages. This causes horrible issues with RTL languages, and looks pretty bad in any language that doesn't exactly follow English semantics (ie, most)