### PR TITLE
submit verified name change

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -476,7 +476,7 @@ class AccountSettingsPage extends React.Component {
             type="text"
             value={
               verifiedNameEnabled
-              && verifiedName.status === 'submitted'
+              && verifiedName?.status === 'submitted'
               && this.props.formValues.pending_name_change
                 ? this.props.formValues.pending_name_change
                 : this.props.formValues.name

--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -840,8 +840,12 @@ AccountSettingsPage.propTypes = {
   saveSettings: PropTypes.func.isRequired,
   fetchSettings: PropTypes.func.isRequired,
   beginNameChange: PropTypes.func.isRequired,
-  tpaProviders: PropTypes.arrayOf(PropTypes.object),
-  nameChangeModal: PropTypes.object,
+  tpaProviders: PropTypes.arrayOf(PropTypes.shape({
+    connected: PropTypes.bool,
+  })),
+  nameChangeModal: PropTypes.shape({
+    formId: PropTypes.string,
+  }),
   verifiedNameEnabled: PropTypes.bool,
   verifiedName: PropTypes.shape({
     verified_name: PropTypes.string,

--- a/src/account-settings/AccountSettingsPage.messages.jsx
+++ b/src/account-settings/AccountSettingsPage.messages.jsx
@@ -121,6 +121,11 @@ const messages = defineMessages({
     defaultMessage: 'Verification has been submitted. This usually takes 48 hours or less. Verified name cannot be changed at this time.',
     description: 'Help text for the account settings verified name field when a verified name has been submitted.',
   },
+  'account.settings.field.name.verified.verification.alert': {
+    id: 'account.settings.field.name.verified.verification.help',
+    defaultMessage: 'Enter your name as it appears on your government-issued ID.',
+    description: 'Form label instructing the user to enter the name on their ID.',
+  },
   'account.settings.field.full.name.help.text.submitted': {
     id: 'account.settings.field.full.name.help.text.submitted',
     defaultMessage: 'When identity verification is successful, this name will appear on your certificates and public-facing records. Full name cannot be changed at this time.',

--- a/src/account-settings/EditableField.jsx
+++ b/src/account-settings/EditableField.jsx
@@ -153,7 +153,7 @@ function EditableField(props) {
                 </Button>
               </p>
             </form>
-            {['name', 'verifiedName'].includes(name) && <CertificatePreference fieldName={name} />}
+            {['name', 'verified_name'].includes(name) && <CertificatePreference fieldName={name} />}
           </>
         ),
         default: (

--- a/src/account-settings/certificate-preference/CertificatePreference.jsx
+++ b/src/account-settings/certificate-preference/CertificatePreference.jsx
@@ -42,7 +42,7 @@ function CertificatePreference({
 
   function handleCheckboxChange() {
     if (!checked) {
-      if (fieldName === 'verifiedName') {
+      if (fieldName === 'verified_name') {
         dispatch(updateDraft(formId, true));
       } else {
         dispatch(updateDraft(formId, false));

--- a/src/account-settings/data/actions.js
+++ b/src/account-settings/data/actions.js
@@ -9,6 +9,7 @@ export const OPEN_FORM = 'OPEN_FORM';
 export const CLOSE_FORM = 'CLOSE_FORM';
 export const UPDATE_DRAFT = 'UPDATE_DRAFT';
 export const RESET_DRAFTS = 'RESET_DRAFTS';
+export const BEGIN_NAME_CHANGE = 'BEGIN_NAME_CHANGE';
 
 // FETCH SETTINGS ACTIONS
 
@@ -25,6 +26,7 @@ export const fetchSettingsSuccess = ({
   thirdPartyAuthProviders,
   profileDataManager,
   timeZones,
+  verifiedNameHistory,
 }) => ({
   type: FETCH_SETTINGS.SUCCESS,
   payload: {
@@ -32,6 +34,7 @@ export const fetchSettingsSuccess = ({
     thirdPartyAuthProviders,
     profileDataManager,
     timeZones,
+    verifiedNameHistory,
   },
 });
 
@@ -68,6 +71,10 @@ export const resetDrafts = () => ({
   type: RESET_DRAFTS,
 });
 
+export const beginNameChange = (formId) => ({
+  type: BEGIN_NAME_CHANGE,
+  payload: { formId },
+});
 // SAVE SETTINGS ACTIONS
 
 export const saveSettings = (formId, commitValues) => ({

--- a/src/account-settings/data/reducers.js
+++ b/src/account-settings/data/reducers.js
@@ -8,6 +8,7 @@ import {
   UPDATE_DRAFT,
   RESET_DRAFTS,
   SAVE_MULTIPLE_SETTINGS,
+  BEGIN_NAME_CHANGE,
 } from './actions';
 
 import { reducer as deleteAccountReducer, DELETE_ACCOUNT } from '../delete-account';
@@ -34,6 +35,11 @@ export const defaultState = {
   resetPassword: resetPasswordReducer(),
   nameChange: nameChangeReducer(),
   thirdPartyAuth: thirdPartyAuthReducer(),
+  nameChangeModal: false,
+  verifiedName: null,
+  mostRecentVerifiedName: {},
+  verifiedNameHistory: {},
+  verifiedNameEnabled: false,
 };
 
 const reducer = (state = defaultState, action) => {
@@ -58,6 +64,7 @@ const reducer = (state = defaultState, action) => {
         loading: false,
         loaded: true,
         loadingError: null,
+        verifiedNameHistory: action.payload.verifiedNameHistory,
       };
     case FETCH_SETTINGS.FAILURE:
       return {
@@ -91,6 +98,7 @@ const reducer = (state = defaultState, action) => {
           saveState: null,
           errors: {},
           drafts: {},
+          nameChangeModal: false,
         };
       }
       return state;
@@ -108,6 +116,15 @@ const reducer = (state = defaultState, action) => {
         drafts: {},
       };
 
+    case BEGIN_NAME_CHANGE:
+      return {
+        ...state,
+        saveState: 'error',
+        nameChangeModal: {
+          formId: action.payload.formId,
+        },
+      };
+
     case SAVE_SETTINGS.BEGIN:
       return {
         ...state,
@@ -121,7 +138,6 @@ const reducer = (state = defaultState, action) => {
         values: { ...state.values, ...action.payload.values },
         errors: {},
         confirmationValues: {
-
           ...state.confirmationValues,
           ...action.payload.confirmationValues,
         },

--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -25,6 +25,7 @@ import {
   saveMultipleSettingsBegin,
   saveMultipleSettingsSuccess,
   saveMultipleSettingsFailure,
+  beginNameChange,
 } from './actions';
 
 // Sub-modules
@@ -43,6 +44,7 @@ import {
   getSettings,
   patchSettings,
   getTimeZones,
+  getVerifiedNameHistory,
 } from './service';
 
 export function* handleFetchSettings() {
@@ -59,6 +61,8 @@ export function* handleFetchSettings() {
       userId,
     );
 
+    const verifiedNameHistory = yield call(getVerifiedNameHistory);
+
     if (values.country) { yield put(fetchTimeZones(values.country)); }
 
     yield put(fetchSettingsSuccess({
@@ -66,6 +70,7 @@ export function* handleFetchSettings() {
       thirdPartyAuthProviders,
       profileDataManager,
       timeZones,
+      verifiedNameHistory,
     }));
   } catch (e) {
     yield put(fetchSettingsFailure(e.message));
@@ -103,6 +108,9 @@ export function* handleSaveSettings(action) {
     yield put(closeForm(action.payload.formId));
   } catch (e) {
     if (e.fieldErrors) {
+      if (Object.keys(e.fieldErrors).includes('name')) {
+        yield put(beginNameChange('name'));
+      }
       yield put(saveSettingsFailure({ fieldErrors: e.fieldErrors }));
     } else {
       yield put(saveSettingsFailure(e.message));
@@ -131,6 +139,9 @@ export function* handleSaveMultipleSettings(action) {
     }
   } catch (e) {
     if (e.fieldErrors) {
+      if (Object.keys(e.fieldErrors).includes('name')) {
+        yield put(beginNameChange('name'));
+      }
       yield put(saveMultipleSettingsFailure({ fieldErrors: e.fieldErrors }));
     } else {
       yield put(saveMultipleSettingsFailure(e.message));

--- a/src/account-settings/data/service.js
+++ b/src/account-settings/data/service.js
@@ -240,7 +240,6 @@ export async function getSettings(username, userRoles, userId) {
     shouldDisplayDemographicsQuestionsResponse,
     demographics,
     demographicsOptions,
-    verifiedNameHistory,
   ] = await Promise.all([
     getAccount(username),
     getPreferences(username),
@@ -251,7 +250,6 @@ export async function getSettings(username, userRoles, userId) {
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && shouldDisplayDemographicsQuestions(),
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && getDemographics(userId),
     getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && getDemographicsOptions(),
-    getVerifiedNameHistory(),
   ]);
 
   return {
@@ -264,7 +262,6 @@ export async function getSettings(username, userRoles, userId) {
     shouldDisplayDemographicsSection: shouldDisplayDemographicsQuestionsResponse,
     ...demographics,
     demographicsOptions,
-    verifiedNameHistory,
   };
 }
 

--- a/src/account-settings/name-change/NameChange.jsx
+++ b/src/account-settings/name-change/NameChange.jsx
@@ -22,6 +22,7 @@ import { requestNameChange, requestNameChangeFailure, requestNameChangeReset } f
 import messages from './messages';
 
 function NameChangeModal({
+  targetFormId,
   errors,
   formValues,
   intl,
@@ -30,7 +31,7 @@ function NameChangeModal({
   const dispatch = useDispatch();
   const { push } = useHistory();
   const { username } = getAuthenticatedUser();
-  const [verifiedNameInput, setVerifiedNameInput] = useState('');
+  const [verifiedNameInput, setVerifiedNameInput] = useState(formValues.verified_name || '');
   const [confirmedWarning, setConfirmedWarning] = useState(false);
 
   function resetLocalState() {
@@ -44,7 +45,7 @@ function NameChangeModal({
 
   function handleClose() {
     resetLocalState();
-    dispatch(closeForm('name'));
+    dispatch(closeForm(targetFormId));
     dispatch(saveSettingsReset());
   }
 
@@ -60,7 +61,8 @@ function NameChangeModal({
         verified_name: intl.formatMessage(messages['account.settings.name.change.error.valid.name']),
       }));
     } else {
-      dispatch(requestNameChange(username, formValues.name, verifiedNameInput));
+      const draftProfileName = targetFormId === 'name' ? formValues.name : null;
+      dispatch(requestNameChange(username, draftProfileName, verifiedNameInput));
     }
   }
 
@@ -184,8 +186,12 @@ function NameChangeModal({
 }
 
 NameChangeModal.propTypes = {
+  targetFormId: PropTypes.string.isRequired,
   errors: PropTypes.shape({}).isRequired,
-  formValues: PropTypes.shape({ name: PropTypes.string }).isRequired,
+  formValues: PropTypes.shape({
+    name: PropTypes.string,
+    verified_name: PropTypes.string,
+  }).isRequired,
   saveState: PropTypes.string,
   intl: intlShape.isRequired,
 };

--- a/src/account-settings/name-change/data/actions.js
+++ b/src/account-settings/name-change/data/actions.js
@@ -2,9 +2,9 @@ import { AsyncActionType } from '../../data/utils';
 
 export const REQUEST_NAME_CHANGE = new AsyncActionType('ACCOUNT_SETTINGS', 'REQUEST_NAME_CHANGE');
 
-export const requestNameChange = (username, newName, verifiedName) => ({
+export const requestNameChange = (username, profileName, verifiedName) => ({
   type: REQUEST_NAME_CHANGE.BASE,
-  payload: { username, newName, verifiedName },
+  payload: { username, profileName, verifiedName },
 });
 
 export const requestNameChangeBegin = () => ({

--- a/src/account-settings/name-change/data/sagas.js
+++ b/src/account-settings/name-change/data/sagas.js
@@ -1,5 +1,7 @@
 import { put, call, takeEvery } from 'redux-saga/effects';
 
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
 import { postVerifiedName } from '../../data/service';
 
 import {
@@ -11,13 +13,17 @@ import {
 import { postNameChange } from './service';
 
 export function* handleRequestNameChange(action) {
+  let { name: profileName } = getAuthenticatedUser();
   try {
     yield put(requestNameChangeBegin());
-    yield call(postNameChange, action.payload.newName);
+    if (action.payload.profileName) {
+      yield call(postNameChange, action.payload.profileName);
+      profileName = action.payload.profileName;
+    }
     yield call(postVerifiedName, {
       username: action.payload.username,
       verified_name: action.payload.verifiedName,
-      profile_name: action.payload.newName,
+      profile_name: profileName,
     });
     yield put(requestNameChangeSuccess());
   } catch (err) {


### PR DESCRIPTION
[MST-1029](https://openedx.atlassian.net/browse/MST-1029)

1. Update the NameChange modal to function with both the profile and verified name fields. The UX is effectively the same for updating either name, if you enter verified name into the form it will just prefill the input on the last panel.

2. Was running into some issues were verifiedName in the form was bound to the verifiedName model object. This was causing updating the form to override the object with a string. I did some refactoring to move state values that aren't reflected in the form itself out of the formData object.

There's one functional change as a result of this that could be up for discussion. If the user has a previously approved verified name that name gets pre-populated into the form when changing your profile name. It certainly doesn't have to happen that way, but left it for now.