### PR TITLE
feat: send nameOnAccount as full_name with all IDV submissions when learner has no name change and verified name feature is enabled

### DIFF
--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -11,6 +11,7 @@ import { useNextPanelSlug } from '../routing-utilities';
 import BasePanel from './BasePanel';
 import IdVerificationContext from '../IdVerificationContext';
 import ImagePreview from '../ImagePreview';
+import { VerifiedNameContext } from '../VerifiedNameContext';
 
 import messages from '../IdVerification.messages';
 import CameraHelpWithUpload from '../CameraHelpWithUpload';
@@ -31,6 +32,7 @@ function SummaryPanel(props) {
     portraitPhotoMode,
     idPhotoMode,
   } = useContext(IdVerificationContext);
+  const { verifiedNameEnabled } = useContext(VerifiedNameContext);
   const nameToBeUsed = idPhotoName || nameOnAccount || '';
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submissionError, setSubmissionError] = useState(null);
@@ -72,6 +74,19 @@ function SummaryPanel(props) {
       };
       if (idPhotoName) {
         verificationData.idPhotoName = idPhotoName;
+      } else if (verifiedNameEnabled) {
+        /**
+         * If learner has not entered an idPhotoName on the GetNameIdPanel,
+         * and the verified name feature is enabled, use the current nameOnAccount
+         * when submitting IDV. The reason we only do this if the feature is enabled
+         * is that, when the feature is off, the server will change the learner's
+         * profile name to this value. If we send the idPhotoName on all requests,
+         * even ones where the learner does not change the idPhotoName, then the
+         * server will record that the full name on the learner's profile has
+         * a requested change, even if the name is the same. This will pollute
+         * the history.
+         */
+        verificationData.idPhotoName = nameOnAccount;
       }
       if (optimizelyExperimentName) {
         verificationData.optimizelyExperimentName = optimizelyExperimentName;


### PR DESCRIPTION
MST-1059: https://openedx.atlassian.net/browse/MST-1059

This code change changes how the full_name field is included in the form data sent during IDV submission.

Before, full_name was only included in the form data when the learner entered a different name in the GetNameIdPanel than what was displayed to them as the default (i.e. their full name on their profile). If a full_name was provided in the request, the server would use the supplied full_name when creating the IDV record and would update the learner's full name on their profile accordingly. If a full_name was not provided in the request, then the server would fall back to the current full name on their profile when creating the IDV record and no change to the full name on their profile would occur.

With the introduction of the Verified Name feature, things have changed. Assuming the feature is enabled, the name displayed to the learner is either the most recent pending or approved verified name or their full name on their profile if the former does not exist. This means that it is no longer correct for the server to create an IDV record using the current full name on the learner's profile when full_name is not provided, which, again, occurs if the learner does not change the name submitted with IDV. This is because, if the learner has a pending or approved verified name, that should be prioritzed over the full name on their profile.

This code change sends the full_name field whether or not the learner has modified it in the IDV flow, if the verified name feature is enabled. This allows the server to create a verified name with whatever value is submitted to it through IDV. The reason we only do this if the feature is enabled is that, when the feature is off, the server will change the learner's profile name to this value, as described above. If we send the idPhotoName on all requests, even ones where the learner does not change the idPhotoName, then the server will record that the full name on the learner's profile has a requested change, even if the name is the same. Their name may not change, but this will pollute the history by being logged as a requested change.