### PR TITLE
fix: null check mostRecentVerifiedName

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -449,7 +449,10 @@ class AccountSettingsPage extends React.Component {
     return (
       <>
         <div className="account-section" id="basic-information" ref={this.navLinkRefs['#basic-information']}>
-          {verifiedNameEnabled && this.renderVerifiedNameMessage(this.props.mostRecentVerifiedName)}
+          {
+            verifiedNameEnabled && this.props.mostRecentVerifiedName
+            && this.renderVerifiedNameMessage(this.props.mostRecentVerifiedName)
+          }
 
           <h2 className="section-heading">
             {this.props.intl.formatMessage(messages['account.settings.section.account.information'])}


### PR DESCRIPTION
Found while testing MST-1029 on stage. This property defaults to {} but the api response could cause it to be null. This only happens if the flag is on however so no impact if this were to go out.