### PR TITLE
fix: Display Last Approved Verified Name When Most Recent Verified Name is Pending

### DIFF
--- a/src/account-settings/data/selectors.js
+++ b/src/account-settings/data/selectors.js
@@ -46,6 +46,7 @@ const mostRecentApprovedVerifiedNameValueSelector = createSelector(
     switch (mostRecentVerifiedName && mostRecentVerifiedName.status) {
       case 'approved':
       case 'denied':
+      case 'pending':
         verifiedName = approvedVerifiedName;
         break;
       case 'submitted':
@@ -146,7 +147,7 @@ export const staticFieldsSelector = createSelector(
     if (accountSettings.profileDataManager) {
       staticFields.push('name', 'email', 'country');
     }
-    if (verifiedName && ['pending', 'submitted'].includes(verifiedName.status)) {
+    if (verifiedName && ['submitted'].includes(verifiedName.status)) {
       staticFields.push('verifiedName');
     }
 


### PR DESCRIPTION
[MST-1073](https://openedx.atlassian.net/browse/MST-1073)

When a learner's most recent Verified Name is in the pending state, we should display their most recent approved Verified Name. If such a Verified Name does not exist, do not display any Verified Name. In either case, do not disable or gray out either the Full name or Verified name fields.

This change is being made because we do not want to prevent a learner from editing the Verified name field if their most recent entry is pending. An entry remains in the pending state when a learner has created a Verified name by changing their name on the Account Settings page but has not followed through with submitting their IDV.