### PR TITLE
fix: Checkbox incorrectly tied to profile name

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -192,6 +192,8 @@ class AccountSettingsPage extends React.Component {
     }
     if (values !== this.props.committedValues?.verified_name) {
       this.props.beginNameChange(formId);
+    } else {
+      this.props.saveSettings(formId, values);
     }
   }
 

--- a/src/account-settings/certificate-preference/CertificatePreference.jsx
+++ b/src/account-settings/certificate-preference/CertificatePreference.jsx
@@ -76,7 +76,7 @@ function CertificatePreference({
   }
 
   useEffect(() => {
-    if (fieldName === 'verifiedName') {
+    if (fieldName === 'verified_name') {
       setChecked(useVerifiedNameForCerts);
     } else {
       setChecked(!useVerifiedNameForCerts);

--- a/src/account-settings/certificate-preference/test/CertificatePreference.test.jsx
+++ b/src/account-settings/certificate-preference/test/CertificatePreference.test.jsx
@@ -158,4 +158,17 @@ describe('NameChange', () => {
       type: 'ACCOUNT_SETTINGS__SAVE_SETTINGS',
     });
   });
+
+  it('checks box for verified name', () => {
+    props = {
+      ...props,
+      fieldName: 'verified_name',
+      useVerifiedNameForCerts: true,
+    };
+
+    render(reduxWrapper(<IntlCertificatePreference {...props} />));
+
+    const checkbox = screen.getByLabelText(labelText);
+    expect(checkbox.checked).toEqual(true);
+  });
 });

--- a/src/account-settings/data/selectors.js
+++ b/src/account-settings/data/selectors.js
@@ -63,7 +63,7 @@ const valuesSelector = createSelector(
   mostRecentApprovedVerifiedNameValueSelector,
   (accountSettings, mostRecentApprovedVerifiedNameValue) => {
     let useVerifiedNameForCerts = (
-      accountSettings.values.verifiedNameHistory?.use_verified_name_for_certs || false
+      accountSettings.verifiedNameHistory?.use_verified_name_for_certs || false
     );
 
     if (Object.keys(accountSettings.confirmationValues).includes('useVerifiedNameForCerts')) {


### PR DESCRIPTION
Fixed a bug that incorrectly rendered the certificate preference checkbox upon each page render. The bug caused 
* the checkboxes to both be selected at the same time
* the checkbox to always be selected for the profile name
* wouldn't allow the proper UI changes upon saving a verified name (i.e. save button wouldn't have a spinner, form wouldn't close)

The checkbox selection works correctly now, and the save button for the verified name field also works as expected.