### PR TITLE
fix: approved alert should appear for subsequent approved attempts

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -278,15 +278,20 @@ class AccountSettingsPage extends React.Component {
     }
   }
 
-  renderVerifiedNameSuccessMessage = () => (
-    <OneTimeDismissibleAlert
-      id="dismissedVerifiedNameSuccessMessage"
-      variant="success"
-      icon={CheckCircle}
-      header={this.props.intl.formatMessage(messages['account.settings.field.name.verified.success.message.header'])}
-      body={this.props.intl.formatMessage(messages['account.settings.field.name.verified.success.message'])}
-    />
-  )
+  renderVerifiedNameSuccessMessage = (verifiedName, created) => {
+    const dateValue = new Date(created).valueOf();
+    const id = `dismissedVerifiedNameSuccessMessage-${verifiedName}-${dateValue}`;
+
+    return (
+      <OneTimeDismissibleAlert
+        id={id}
+        variant="success"
+        icon={CheckCircle}
+        header={this.props.intl.formatMessage(messages['account.settings.field.name.verified.success.message.header'])}
+        body={this.props.intl.formatMessage(messages['account.settings.field.name.verified.success.message'])}
+      />
+    );
+  }
 
   renderVerifiedNameFailureMessage = (verifiedName, created) => {
     const dateValue = new Date(created).valueOf();
@@ -342,7 +347,7 @@ class AccountSettingsPage extends React.Component {
 
     switch (status) {
       case 'approved':
-        return this.renderVerifiedNameSuccessMessage();
+        return this.renderVerifiedNameSuccessMessage(verifiedName, created);
       case 'denied':
         return this.renderVerifiedNameFailureMessage(verifiedName, created);
       case 'submitted':


### PR DESCRIPTION
## [MST-1072](https://openedx.atlassian.net/browse/MST-1072)

Current behavior:
- Learner changes their name, is prompted to complete IDV, and it is approved
- Learner dismisses the "approved" alert on their account settings page
- Learner submits another name change, and it is approved
- The "approved" alert will not appear again on the account settings page, because the local storage value determining whether the alert has been dismissed still persists in the browser

Behavior with fix:
- Learner changes their name, is prompted to complete IDV, and it is approved
- Learner dismisses the "approved" alert on their account settings page
- Learner submits another name change, and it is approved
- New "approved" alert is visible on their account settings page