### PR TITLE
[MST-1089] Only display name change modal when backend requires verification

### DIFF
--- a/src/account-settings/data/sagas.js
+++ b/src/account-settings/data/sagas.js
@@ -108,7 +108,7 @@ export function* handleSaveSettings(action) {
     yield put(closeForm(action.payload.formId));
   } catch (e) {
     if (e.fieldErrors) {
-      if (Object.keys(e.fieldErrors).includes('name')) {
+      if (e.fieldErrors.name?.includes('verification')) {
         yield put(beginNameChange('name'));
       }
       yield put(saveSettingsFailure({ fieldErrors: e.fieldErrors }));
@@ -139,7 +139,7 @@ export function* handleSaveMultipleSettings(action) {
     }
   } catch (e) {
     if (e.fieldErrors) {
-      if (Object.keys(e.fieldErrors).includes('name')) {
+      if (e.fieldErrors.name?.includes('verification')) {
         yield put(beginNameChange('name'));
       }
       yield put(saveMultipleSettingsFailure({ fieldErrors: e.fieldErrors }));


### PR DESCRIPTION
[MST-1089](https://openedx.atlassian.net/browse/MST-1089)

Fixes an issue where the name change modal would trigger for any error related to the "full name" field, rather than just when the name change requires ID verification.

This is the relevant check on the backend: https://github.com/edx/edx-platform/blob/0935b5c51fa4115caa6d6d98b0ef65fea4fcdec1/openedx/core/djangoapps/user_api/accounts/api.py#L239