### PR TITLE
MST-1065: Add Copy and UI Treatment for Name Affirmation When Enabled 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 const { createConfig } = require('@edx/frontend-build');
 
 module.exports = createConfig('jest', {
-  setupFiles: [
+  setupFilesAfterEnv: [
     '<rootDir>/src/setupTest.js',
   ],
 });

--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -526,25 +526,55 @@ const messages = defineMessages({
     defaultMessage: 'Account Name Check',
     description: 'Title for the Account Name Check page.',
   },
+  'id.verification.name.check.title': {
+    id: 'id.verification.name.check.title',
+    defaultMessage: 'Double-check your name',
+    description: 'Title for the page where a user double-checks that their name is correct.',
+  },
   'id.verification.account.name.instructions': {
     id: 'id.verification.account.name.instructions',
     defaultMessage: 'The name on your account and the name on your ID must be an exact match. If not, please click "No" to update your account name.',
     description: 'Text to verify that the account name matches the name on the ID photo.',
+  },
+  'id.verification.name.check.instructions': {
+    id: 'id.verification.name.check.instructions',
+    defaultMessage: 'Does the name below match the name on your government-issued ID? If not, update the Name below to match your goverment-issued ID.',
+    description: 'Text to instruct the user to check that the name displayed on the page matches what is on their government-issued ID.',
+  },
+  'id.verification.name.check.mismatch.information': {
+    id: 'id.verification.name.check.mismatch.information',
+    defaultMessage: 'If the name below does not match your government-issued ID, your identity verification will be denied.',
+    description: 'Text to inform the user that if the name displayed on the page does not match what is on their government-issued ID, identity verification will be denied.',
   },
   'id.verification.account.name.radio.label': {
     id: 'id.verification.account.name.radio.label',
     defaultMessage: 'Does the name on your ID match the Account Name below?',
     description: 'Question to ask the user whether their account name match the name on their ID card.',
   },
+  'id.verification.name.check.radio.label': {
+    id: 'id.verification.name.check.radio.label',
+    defaultMessage: 'Select an option',
+    description: 'Label for a radio button group where the user needs to choose one of two options.',
+  },
   'id.verification.account.name.radio.yes': {
     id: 'id.verification.account.name.radio.yes',
     defaultMessage: 'Yes',
     description: 'The radio button that says the account name matches.',
   },
+  'id.verification.name.check.radio.yes': {
+    id: 'id.verification.name.check.radio.yes',
+    defaultMessage: 'Yes, the name below matches my ID',
+    description: 'Label for a radio button that indicates that the name displayed on the page matches the name on the user\'s ID.',
+  },
   'id.verification.account.name.radio.no': {
     id: 'id.verification.account.name.radio.no',
     defaultMessage: 'No',
     description: 'The radio button that says the account name does not match.',
+  },
+  'id.verification.name.check.radio.no': {
+    id: 'id.verification.name.check.radio.no',
+    defaultMessage: 'No, the name below does not match my ID',
+    description: 'Label for a radio button that indicates that the name displayed on the page does not match the name on the user\'s ID.',
   },
   'id.verification.account.name.error': {
     id: 'id.verification.account.name.error',
@@ -565,6 +595,11 @@ const messages = defineMessages({
     id: 'id.verification.account.name.label',
     defaultMessage: 'Account Name',
     description: 'Label for account name input.',
+  },
+  'id.verification.name.label': {
+    id: 'id.verification.name.label',
+    defaultMessage: 'Name',
+    description: 'Label for name input.',
   },
   'id.verification.account.name.photo.alt': {
     id: 'id.verification.account.name.photo.alt',

--- a/src/id-verification/_id-verification.scss
+++ b/src/id-verification/_id-verification.scss
@@ -14,14 +14,6 @@
         max-height: 10rem;
       }
     }
-    .form-check {
-      padding: 0.5rem 0.5rem 1rem;
-      .form-check-label {
-        margin-left: 0.5rem;
-        padding-top: 0.2rem;
-        font-weight: normal;
-      }
-    }
   }
   .action-row {
     display: flex;

--- a/src/id-verification/panels/GetNameIdPanel.jsx
+++ b/src/id-verification/panels/GetNameIdPanel.jsx
@@ -10,6 +10,7 @@ import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/
 import { useNextPanelSlug } from '../routing-utilities';
 import BasePanel from './BasePanel';
 import IdVerificationContext from '../IdVerificationContext';
+import { VerifiedNameContext } from '../VerifiedNameContext';
 
 import messages from '../IdVerification.messages';
 
@@ -23,6 +24,7 @@ function GetNameIdPanel(props) {
   const {
     nameOnAccount, userId, profileDataManager, idPhotoName, setIdPhotoName,
   } = useContext(IdVerificationContext);
+  const { verifiedNameEnabled } = useContext(VerifiedNameContext);
   const nameOnAccountValue = nameOnAccount || '';
   const invalidName = !nameMatches && (!idPhotoName || idPhotoName === nameOnAccount);
   const blankName = !nameOnAccount && !idPhotoName;
@@ -91,62 +93,77 @@ function GetNameIdPanel(props) {
   return (
     <BasePanel
       name={panelSlug}
-      title={props.intl.formatMessage(messages['id.verification.account.name.title'])}
+      title={
+        verifiedNameEnabled
+          ? props.intl.formatMessage(messages['id.verification.name.check.title'])
+          : props.intl.formatMessage(messages['id.verification.account.name.title'])
+      }
     >
       <p>
-        {props.intl.formatMessage(messages['id.verification.account.name.instructions'])}
+        {
+          verifiedNameEnabled
+            ? props.intl.formatMessage(messages['id.verification.name.check.instructions'])
+            : props.intl.formatMessage(messages['id.verification.account.name.instructions'])
+        }
+      </p>
+      <p>
+        {verifiedNameEnabled && props.intl.formatMessage(messages['id.verification.name.check.mismatch.information'])}
       </p>
 
       <Form onSubmit={handleSubmit}>
         <Form.Group>
-          <Form.Label htmlFor="nameMatchesYes">
-            {props.intl.formatMessage(messages['id.verification.account.name.radio.label'])}
+          <Form.Label className="font-weight-bold" htmlFor="nameMatchesYes">
+            {
+              verifiedNameEnabled
+                ? props.intl.formatMessage(messages['id.verification.name.check.radio.label'])
+                : props.intl.formatMessage(messages['id.verification.account.name.radio.label'])
+            }
           </Form.Label>
-          <Form.Row>
-            <Form.Check
-              type="radio"
-              id="nameMatchesYes"
-              name="nameMatches"
-              data-testid="name-matches-yes"
-              label={props.intl.formatMessage(messages['id.verification.account.name.radio.yes'])}
-              checked={nameMatches}
-              disabled={!nameOnAccount}
-              inline
-              onChange={() => {
-                setNameMatches(true);
-                setIdPhotoName(null);
-              }}
-            />
-            <Form.Check
-              type="radio"
-              id="nameMatchesNo"
-              name="nameMatches"
-              data-testid="name-matches-no"
-              label={props.intl.formatMessage(messages['id.verification.account.name.radio.no'])}
-              checked={!nameMatches}
-              disabled={!nameOnAccount}
-              inline
-              onChange={() => setNameMatches(false)}
-            />
-          </Form.Row>
+          <Form.Check
+            type="radio"
+            id="nameMatchesYes"
+            name="nameMatches"
+            data-testid="name-matches-yes"
+            label={verifiedNameEnabled ? props.intl.formatMessage(messages['id.verification.name.check.radio.yes']) : props.intl.formatMessage(messages['id.verification.account.name.radio.yes'])}
+            checked={nameMatches}
+            disabled={!nameOnAccount}
+            onChange={() => {
+              setNameMatches(true);
+              setIdPhotoName(null);
+            }}
+          />
+          <Form.Check
+            type="radio"
+            id="nameMatchesNo"
+            name="nameMatches"
+            data-testid="name-matches-no"
+            label={verifiedNameEnabled ? props.intl.formatMessage(messages['id.verification.name.check.radio.no']) : props.intl.formatMessage(messages['id.verification.account.name.radio.no'])}
+            checked={!nameMatches}
+            disabled={!nameOnAccount}
+            onChange={() => setNameMatches(false)}
+          />
         </Form.Group>
         <Form.Group>
-          <Form.Label htmlFor="photo-id-name">
-            {props.intl.formatMessage(messages['id.verification.account.name.label'])}
+          <Form.Label className="font-weight-bold" htmlFor="photo-id-name">
+            {
+              verifiedNameEnabled
+                ? props.intl.formatMessage(messages['id.verification.name.label'])
+                : props.intl.formatMessage(messages['id.verification.account.name.label'])
+            }
           </Form.Label>
           <Form.Control
             controlId="photo-id-name"
             size="lg"
             type="text"
             ref={nameInputRef}
-            readOnly={nameMatches || profileDataManager}
+            readOnly={nameMatches || !!profileDataManager}
             isInvalid={invalidName || blankName}
             aria-describedby="photo-id-name-feedback"
             value={getNameValue()}
             onChange={e => setIdPhotoName(e.target.value)}
             data-testid="name-input"
           />
-          {(invalidName || profileDataManager) && (
+          {(invalidName || !!profileDataManager) && (
             <Form.Control.Feedback
               id="photo-id-name-feedback"
               data-testid="id-name-feedback-message"

--- a/src/id-verification/panels/SummaryPanel.jsx
+++ b/src/id-verification/panels/SummaryPanel.jsx
@@ -220,14 +220,16 @@ function SummaryPanel(props) {
       {!optimizelyExperimentName && <CameraHelpWithUpload />}
       <div className="form-group">
         <label htmlFor="name-to-be-used" className="font-weight-bold">
-          {props.intl.formatMessage(messages['id.verification.account.name.label'])}
+          {verifiedNameEnabled
+            ? props.intl.formatMessage(messages['id.verification.name.label'])
+            : props.intl.formatMessage(messages['id.verification.account.name.label'])}
         </label>
         {renderManagedProfileMessage()}
         <div className="d-flex">
           <Input
             id="name-to-be-used"
             type="text"
-            readOnly
+            disabled
             value={nameToBeUsed}
             onChange={() => {}}
             aria-describedby={profileDataManager ? 'profile-manager-warning' : null}
@@ -240,14 +242,29 @@ function SummaryPanel(props) {
                 state: { fromSummary: true },
               }}
             >
-              <FormattedMessage
-                id="id.verification.account.name.edit"
-                defaultMessage="Edit {sr}"
-                description="Button to edit account name, with clarifying information for screen readers."
-                values={{
-                  sr: <span className="sr-only">Account Name</span>,
-                }}
-              />
+              {
+                verifiedNameEnabled
+                  ? (
+                    <FormattedMessage
+                      id="id.verification.account.name.edit"
+                      defaultMessage="Edit {sr}"
+                      description="Button to edit account name, with clarifying information for screen readers."
+                      values={{
+                        sr: <span className="sr-only">Name</span>,
+                      }}
+                    />
+                  )
+                  : (
+                    <FormattedMessage
+                      id="id.verification.account.name.edit"
+                      defaultMessage="Edit {sr}"
+                      description="Button to edit account name, with clarifying information for screen readers."
+                      values={{
+                        sr: <span className="sr-only">Account Name</span>,
+                      }}
+                    />
+                  )
+              }
             </Link>
           )}
         </div>

--- a/src/id-verification/tests/AccessBlocked.test.jsx
+++ b/src/id-verification/tests/AccessBlocked.test.jsx
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 

--- a/src/id-verification/tests/Camera.test.jsx
+++ b/src/id-verification/tests/Camera.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import '@testing-library/jest-dom/extend-expect';
 import {
   render, cleanup, screen, act, fireEvent,
 } from '@testing-library/react';

--- a/src/id-verification/tests/CollapsibleImageHelp.test.jsx
+++ b/src/id-verification/tests/CollapsibleImageHelp.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import '@testing-library/jest-dom/extend-expect';
 import {
   render, cleanup, screen, act, fireEvent,
 } from '@testing-library/react';

--- a/src/id-verification/tests/IdVerificationContextProvider.test.jsx
+++ b/src/id-verification/tests/IdVerificationContextProvider.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, cleanup, act } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/id-verification/tests/VerifiedNameContextProvider.test.jsx
+++ b/src/id-verification/tests/VerifiedNameContextProvider.test.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { render, cleanup, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 
 import { getVerifiedNameHistory } from '../../account-settings/data/service';
 import { VerifiedNameContext, VerifiedNameContextProvider } from '../VerifiedNameContext';

--- a/src/id-verification/tests/panels/ChooseModePanel.test.jsx
+++ b/src/id-verification/tests/panels/ChooseModePanel.test.jsx
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import ChooseModePanel from '../../panels/ChooseModePanel';

--- a/src/id-verification/tests/panels/IdContextPanel.test.jsx
+++ b/src/id-verification/tests/panels/IdContextPanel.test.jsx
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';

--- a/src/id-verification/tests/panels/PortraitPhotoContextPanel.test.jsx
+++ b/src/id-verification/tests/panels/PortraitPhotoContextPanel.test.jsx
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import PortraitPhotoContextPanel from '../../panels/PortraitPhotoContextPanel';

--- a/src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx
+++ b/src/id-verification/tests/panels/RequestCameraAccessPanel.test.jsx
@@ -5,7 +5,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, screen, cleanup, act, fireEvent,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import RequestCameraAccessPanel from '../../panels/RequestCameraAccessPanel';

--- a/src/id-verification/tests/panels/SubmittedPanel.test.jsx
+++ b/src/id-verification/tests/panels/SubmittedPanel.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import '@testing-library/jest-dom/extend-expect';
 import {
   render, cleanup, act, screen,
 } from '@testing-library/react';

--- a/src/id-verification/tests/panels/SummaryPanel.test.jsx
+++ b/src/id-verification/tests/panels/SummaryPanel.test.jsx
@@ -5,7 +5,6 @@ import {
   render, cleanup, act, screen, fireEvent, waitFor,
 } from '@testing-library/react';
 import '@edx/frontend-platform/analytics';
-import '@testing-library/jest-dom/extend-expect';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import * as dataService from '../../data/service';
 import IdVerificationContext from '../../IdVerificationContext';

--- a/src/id-verification/tests/panels/TakeIdPhotoPanel.test.jsx
+++ b/src/id-verification/tests/panels/TakeIdPhotoPanel.test.jsx
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import TakeIdPhotoPanel from '../../panels/TakeIdPhotoPanel';

--- a/src/id-verification/tests/panels/TakePortraitPhotoPanel.test.jsx
+++ b/src/id-verification/tests/panels/TakePortraitPhotoPanel.test.jsx
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import {
   render, cleanup, act, screen, fireEvent,
 } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import IdVerificationContext from '../../IdVerificationContext';
 import TakePortraitPhotoPanel from '../../panels/TakePortraitPhotoPanel';

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,5 +1,6 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';


### PR DESCRIPTION
[MST-1065](https://openedx.atlassian.net/browse/MST-1065)

When the Name Affirmation feature is enabled, a few panels in the IDV workflow should have different copy to reflect the changes associated with Name Affirmation. This is because entering a new during the IDV flow (GetNameIdPanel) will no longer modify the learner's "Account Name". Furthermore, "Account Name" is an ambiguous term; it's not clear that it refers to the learner's full name on their profile. These copy changes make the panel more generic and remove details about name changes. The SummaryPanel also has a minor copy change to change "Account Name" to "Name".

These code changes also include some UI changes.

**Before:**
![image](https://user-images.githubusercontent.com/11871801/135669409-3d3ad461-a8b6-4abf-bfc3-76de1e99d942.png)
![image](https://user-images.githubusercontent.com/11871801/135669463-ee5b8982-67f8-4baf-a9f8-f7864895f4bd.png)


**After:**

![image](https://user-images.githubusercontent.com/11871801/135669223-cb46c61b-f999-4f76-9367-fe3dc537b0e2.png)
![image](https://user-images.githubusercontent.com/11871801/135669606-c03b2c54-edbd-4978-a172-b46751f45e0b.png)