### PR TITLE
[MST-1104] Redirect user to original location after IDV

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "formdata-polyfill": "4.0.10",
     "history": "4.10.1",
     "jslib-html5-camera-photo": "3.1.8",
+    "lodash.camelcase": "^4.3.0",
     "lodash.debounce": "4.0.8",
     "lodash.findindex": "4.6.0",
     "lodash.get": "4.4.2",

--- a/src/account-settings/name-change/NameChange.jsx
+++ b/src/account-settings/name-change/NameChange.jsx
@@ -69,7 +69,7 @@ function NameChangeModal({
   useEffect(() => {
     if (saveState === 'complete') {
       handleClose();
-      push('/id-verification');
+      push('/id-verification?next=account%2Fsettings');
     }
   }, [saveState]);
 

--- a/src/id-verification/IdVerification.messages.js
+++ b/src/id-verification/IdVerification.messages.js
@@ -701,6 +701,11 @@ const messages = defineMessages({
     defaultMessage: 'Return to Course',
     description: 'Return to the course which ID verification was accessed from.',
   },
+  'id.verification.return.generic': {
+    id: 'id.verification.return.generic',
+    defaultMessage: 'Return',
+    description: 'Button to return to the user\'s original location.',
+  },
   'id.verification.photo.upload.help.title': {
     id: 'id.verification.photo.upload.help.title',
     defaultMessage: 'Upload a Photo Instead',

--- a/src/id-verification/IdVerificationPage.jsx
+++ b/src/id-verification/IdVerificationPage.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import {
   Route, Switch, Redirect, useRouteMatch, useLocation,
 } from 'react-router-dom';
+import camelCase from 'lodash.camelcase';
 import qs from 'qs';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Modal, Button } from '@edx/paragon';
@@ -32,16 +33,16 @@ function IdVerificationPage(props) {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // Course run key is passed as a query string
+  // Save query params in order to route back to the correct location later
   useEffect(() => {
     if (search) {
-      const parsed = qs.parse(search, {
+      const parsedQueryParams = qs.parse(search, {
         ignoreQueryPrefix: true,
         interpretNumericEntities: true,
       });
-      if (Object.prototype.hasOwnProperty.call(parsed, 'course_id') && parsed.course_id) {
-        sessionStorage.setItem('courseRunKey', parsed.course_id);
-      }
+      Object.entries(parsedQueryParams).forEach(([key, value]) => {
+        sessionStorage.setItem(camelCase(key), value);
+      });
     }
   }, [search]);
 

--- a/src/id-verification/panels/RequestCameraAccessPanel.jsx
+++ b/src/id-verification/panels/RequestCameraAccessPanel.jsx
@@ -38,12 +38,15 @@ function RequestCameraAccessPanel(props) {
     }
   }, [mediaAccess, userId]);
 
-  // If the user accessed IDV through a course,
-  // link back to that course rather than the dashboard
+  // Link back to the correct location if the user accessed IDV somewhere other
+  // than the dashboard
   useEffect(() => {
-    if (sessionStorage.getItem('courseRunKey')) {
-      setReturnUrl(`courses/${sessionStorage.getItem('courseRunKey')}`);
+    if (sessionStorage.getItem('courseId')) {
+      setReturnUrl(`courses/${sessionStorage.getItem('courseId')}`);
       setReturnText('id.verification.return.course');
+    } else if (sessionStorage.getItem('next')) {
+      setReturnUrl(sessionStorage.getItem('next'));
+      setReturnText('id.verification.return.generic');
     }
   }, []);
 
@@ -57,7 +60,7 @@ function RequestCameraAccessPanel(props) {
     return props.intl.formatMessage(messages['id.verification.camera.access.title']);
   };
 
-  const returnToDashboardLink = (
+  const returnLink = (
     <a className="btn btn-primary" href={`${getConfig().LMS_BASE_URL}/${returnUrl}`}>
       {props.intl.formatMessage(messages[returnText])}
     </a>
@@ -114,7 +117,7 @@ function RequestCameraAccessPanel(props) {
           </p>
           <EnableCameraDirectionsPanel browserName={browserName} intl={props.intl} />
           <div className="action-row">
-            {optimizelyExperimentName ? nextButtonLink : returnToDashboardLink}
+            {optimizelyExperimentName ? nextButtonLink : returnLink}
           </div>
         </div>
       )}
@@ -126,7 +129,7 @@ function RequestCameraAccessPanel(props) {
           </p>
           <UnsupportedCameraDirectionsPanel browserName={browserName} intl={props.intl} />
           <div className="action-row">
-            {optimizelyExperimentName ? nextButtonLink : returnToDashboardLink}
+            {optimizelyExperimentName ? nextButtonLink : returnLink}
           </div>
         </div>
       )}

--- a/src/id-verification/panels/SubmittedPanel.jsx
+++ b/src/id-verification/panels/SubmittedPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -10,6 +10,8 @@ import messages from '../IdVerification.messages';
 
 function SubmittedPanel(props) {
   const { userId } = useContext(IdVerificationContext);
+  const [returnUrl, setReturnUrl] = useState('dashboard');
+  const [returnText, setReturnText] = useState('id.verification.return.dashboard');
   const panelSlug = 'submitted';
 
   useEffect(() => {
@@ -18,6 +20,18 @@ function SubmittedPanel(props) {
       user_id: userId,
     });
   }, [userId]);
+
+  // Link back to the correct location if the user accessed IDV somewhere other
+  // than the dashboard
+  useEffect(() => {
+    if (sessionStorage.getItem('courseId')) {
+      setReturnUrl(`courses/${sessionStorage.getItem('courseId')}`);
+      setReturnText('id.verification.return.course');
+    } else if (sessionStorage.getItem('next')) {
+      setReturnUrl(sessionStorage.getItem('next'));
+      setReturnText('id.verification.return.generic');
+    }
+  }, []);
 
   return (
     <BasePanel
@@ -29,10 +43,10 @@ function SubmittedPanel(props) {
       </p>
       <a
         className="btn btn-primary"
-        href={`${getConfig().LMS_BASE_URL}/dashboard`}
+        href={`${getConfig().LMS_BASE_URL}/${returnUrl}`}
         data-testid="return-button"
       >
-        {props.intl.formatMessage(messages['id.verification.return.dashboard'])}
+        {props.intl.formatMessage(messages[returnText])}
       </a>
     </BasePanel>
   );

--- a/src/id-verification/tests/IdVerificationPage.test.jsx
+++ b/src/id-verification/tests/IdVerificationPage.test.jsx
@@ -41,34 +41,6 @@ describe('IdVerificationPage', () => {
     intl: {},
   };
 
-  it('does not store irrelevant query params', async () => {
-    history.push('/?test=irrelevant');
-    await act(async () => render((
-      <Router history={history}>
-        <IntlProvider locale="en">
-          <Provider store={store}>
-            <IntlIdVerificationPage {...props} />
-          </Provider>
-        </IntlProvider>
-      </Router>
-    )));
-    expect(sessionStorage.setItem).toHaveBeenCalledTimes(0);
-  });
-
-  it('does not store empty course_id', async () => {
-    history.push('/?course_id=');
-    await act(async () => render((
-      <Router history={history}>
-        <IntlProvider locale="en">
-          <Provider store={store}>
-            <IntlIdVerificationPage {...props} />
-          </Provider>
-        </IntlProvider>
-      </Router>
-    )));
-    expect(sessionStorage.setItem).toHaveBeenCalledTimes(0);
-  });
-
   it('decodes and stores course_id', async () => {
     history.push('/?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course');
     await act(async () => render((
@@ -81,8 +53,25 @@ describe('IdVerificationPage', () => {
       </Router>
     )));
     expect(sessionStorage.setItem).toHaveBeenCalledWith(
-      'courseRunKey',
+      'courseId',
       'course-v1:edX+DemoX+Demo_Course',
+    );
+  });
+
+  it('stores `next` value', async () => {
+    history.push('/?next=dashboard');
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <Provider store={store}>
+            <IntlIdVerificationPage {...props} />
+          </Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      'next',
+      'dashboard',
     );
   });
 });

--- a/src/id-verification/tests/panels/SubmittedPanel.test.jsx
+++ b/src/id-verification/tests/panels/SubmittedPanel.test.jsx
@@ -28,14 +28,20 @@ describe('SubmittedPanel', () => {
   };
 
   beforeEach(() => {
-    global.sessionStorage.getItem = jest.fn();
+    const mockStorage = {};
+    global.Storage.prototype.setItem = jest.fn((key, value) => {
+      mockStorage[key] = value;
+    });
+    global.Storage.prototype.getItem = jest.fn(key => mockStorage[key]);
   });
 
   afterEach(() => {
+    global.Storage.prototype.setItem.mockReset();
+    global.Storage.prototype.getItem.mockReset();
     cleanup();
   });
 
-  it('links to dashboard without courseRunKey', async () => {
+  it('links to dashboard without courseId or next value', async () => {
     await act(async () => render((
       <Router history={history}>
         <IntlProvider locale="en">
@@ -47,5 +53,38 @@ describe('SubmittedPanel', () => {
     )));
     const button = await screen.findByTestId('return-button');
     expect(button).toHaveTextContent(/Return to Your Dashboard/);
+    expect(button).toHaveAttribute('href', `${process.env.LMS_BASE_URL}/dashboard`);
+  });
+
+  it('links to course when courseId is stored', async () => {
+    sessionStorage.setItem('courseId', 'course-v1:edX+DemoX+Demo_Course');
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlSubmittedPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const button = await screen.findByTestId('return-button');
+    expect(button).toHaveTextContent(/Return to Course/);
+    expect(button).toHaveAttribute('href', `${process.env.LMS_BASE_URL}/courses/course-v1:edX+DemoX+Demo_Course`);
+  });
+
+  it('links to specified page when `next` value is provided', async () => {
+    sessionStorage.setItem('next', 'some_page');
+    await act(async () => render((
+      <Router history={history}>
+        <IntlProvider locale="en">
+          <IdVerificationContext.Provider value={contextValue}>
+            <IntlSubmittedPanel {...defaultProps} />
+          </IdVerificationContext.Provider>
+        </IntlProvider>
+      </Router>
+    )));
+    const button = await screen.findByTestId('return-button');
+    expect(button).toHaveTextContent(/Return/);
+    expect(button).toHaveAttribute('href', `${process.env.LMS_BASE_URL}/some_page`);
   });
 });


### PR DESCRIPTION
[MST-1104](https://openedx.atlassian.net/browse/MST-1104)

Allow IDV to store a `next` value from query parameters, which is used to determine where to redirect the user after completing IDV (or failing to enable their camera).

This also fixes an issue where the course ID was being passed in after accessing IDV from a course, but the user wasn't actually being redirected back to said course.